### PR TITLE
 Fix #174: sort users to invite alphabetically 

### DIFF
--- a/client/views/common/inviteUserModal/inviteUserModal.coffee
+++ b/client/views/common/inviteUserModal/inviteUserModal.coffee
@@ -2,11 +2,11 @@ Template.inviteUserModal.helpers
 
 	getUsers: ->
 		projectId = FlowRouter.getParam('projectId')
-		language = TAPi18n.getLanguage()
 		users = Roles.getUsersInRole Permissions.member, projectId
+		collator = new Intl.Collator(TAPi18n.getLanguage())
 		users.fetch().sort (u1, u2) ->
-			u1.profile.lastname.localeCompare(u2.profile.lastname, language) ||
-				u1.profile.firstname.localeCompare(u2.profile.firstname, language)
+			collator.compare(u1.profile.lastname, u2.profile.lastname) ||
+				collator.compare(u1.profile.firstname, u2.profile.firstname)
 
 	getState: ->
 		if @state == 'invited'

--- a/client/views/common/inviteUserModal/inviteUserModal.coffee
+++ b/client/views/common/inviteUserModal/inviteUserModal.coffee
@@ -2,12 +2,11 @@ Template.inviteUserModal.helpers
 
 	getUsers: ->
 		projectId = FlowRouter.getParam('projectId')
+		language = TAPi18n.getLanguage()
 		users = Roles.getUsersInRole Permissions.member, projectId
 		users.fetch().sort (u1, u2) ->
-			if u1.profile.lastname != u2.profile.lastname
-				u1.profile.lastname > u2.profile.lastname
-			else
-				u1.profile.firstname > u2.profile.firstname
+			u1.profile.lastname.localeCompare(u2.profile.lastname, language) ||
+				u1.profile.firstname.localeCompare(u2.profile.firstname, language)
 
 	getState: ->
 		if @state == 'invited'


### PR DESCRIPTION
https://caniuse.com/#search=intl sagt iOS Safari 9.3 kann keine Intl API. Sollen wir dafür ne Verzweigung einbauen oder ist das nicht schlimm?