### PR TITLE
Fix checks for null/undefined

### DIFF
--- a/client/lib/footable/footable.js
+++ b/client/lib/footable/footable.js
@@ -466,7 +466,7 @@
   F.is.element = function (obj) {
     return typeof HTMLElement === 'object'
       ? obj instanceof HTMLElement
-      : obj && typeof obj === 'object' && obj !== null && obj.nodeType === 1 && typeof obj.nodeName === 'string'
+      : obj && typeof obj === 'object' && obj != null && obj.nodeType === 1 && typeof obj.nodeName === 'string'
   }
 
   /**
@@ -3997,7 +3997,7 @@
       }
       self.ft.$el.addClass('footable-filtering').addClass(position)
 
-      self.$container = self.container === null ? $() : $(self.container).first()
+      self.$container = self.container == null ? $() : $(self.container).first()
       if (!self.$container.length) {
         // add it to a row and then populate it with the search input and column selector dropdown.
         self.$row = $('<tr/>', { 'class': 'footable-filtering' }).prependTo(self.ft.$el.children('thead'))
@@ -4917,7 +4917,7 @@
     hasChanged: function () {
       return !(!this.initial || !this.column ||
 				(this.column.name === this.initial.column &&
-					(this.column.direction === this.initial.direction || (this.initial.direction === null && this.column.direction === 'ASC')))
+					(this.column.direction === this.initial.direction || (this.initial.direction == null && this.column.direction === 'ASC')))
       )
     },
     /**
@@ -5545,7 +5545,7 @@
       }
       this.ft.$el.addClass('footable-paging').addClass(position)
 
-      this.$container = this.container === null ? null : $(this.container).first()
+      this.$container = this.container == null ? null : $(this.container).first()
       if (!F.is.jq(this.$container)) {
         var $tfoot = this.ft.$el.children('tfoot')
         if ($tfoot.length == 0) {

--- a/client/views/pages/wiki/wiki.js
+++ b/client/views/pages/wiki/wiki.js
@@ -6,7 +6,7 @@ import { FlowRouter } from 'meteor/kadira:flow-router'
 Template.wiki.helpers({
   tabs: function () {
     const project = Projects.findOne(FlowRouter.getParam('projectId'))
-    return project !== null ? project.wiki !== null ? project.wiki.tabs : void 0 : void 0
+    return project != null ? project.wiki != null ? project.wiki.tabs : void 0 : void 0
   },
   files: function () {
     const projectId = FlowRouter.getParam('projectId')

--- a/imports/api/calendar/service.js
+++ b/imports/api/calendar/service.js
@@ -100,7 +100,7 @@ Meteor.methods({
             for (let request of team.pending) {
               for (let user of users) {
                 if (user._id === request._id) {
-                  if (user.roles[Roles.GLOBAL_GROUP] !== null &&
+                  if (user.roles[Roles.GLOBAL_GROUP] != null &&
                     user.roles[Roles.GLOBAL_GROUP].indexOf('teamleader') > -1) {
                     team.isTlNeeded = false
                     break
@@ -143,7 +143,7 @@ Meteor.methods({
 function checkPermissions (projectId) {
   const project = Projects.findOne(projectId, { fields: { _id: 1 } })
 
-  if (project === null) {
+  if (project == null) {
     throw new Meteor.Error('projectNotFound')
   }
 

--- a/imports/api/dashboard/Functions.js
+++ b/imports/api/dashboard/Functions.js
@@ -54,7 +54,7 @@ function getUpdatedShifts (projects, shifts) {
         return t._id === shift.tagId
       })[0]
 
-      if (project !== null && tag !== null) {
+      if (project != null && tag != null) {
         shift.tag = tag.name
         shift.date = parseInt(moment(shift.date, 'YYYYDDD').format('YYYYMMDD'), 10)
 
@@ -67,7 +67,7 @@ function getUpdatedShifts (projects, shifts) {
     return null
   })
     .filter((shift) => {
-      return shift !== null
+      return shift != null
     })
 }
 
@@ -90,7 +90,7 @@ function getMissingShiftReports (projectIds, projects, date, userId) {
     .filter((shift) => {
     // only return shift if my team hasn't submitted the report yet
       return shift.teams.filter((team) => {
-        return team.report === null || !team.report.submitted
+        return team.report == null || !team.report.submitted
       }).length > 0
     })
 

--- a/imports/api/notes/service.js
+++ b/imports/api/notes/service.js
@@ -112,7 +112,7 @@ function getExtendedNote (projectId, noteId) {
     }
   }
 
-  if (note !== null) {
+  if (note != null) {
     const user = Users.findOne(note.lastChangeBy, {
       fields: {
         'profile.firstname': 1,
@@ -140,7 +140,7 @@ function getExtendedNote (projectId, noteId) {
 function checkPermissions (projectId) {
   const project = Projects.findOne(projectId, { fields: { _id: 1 } })
 
-  if (project === null) {
+  if (project == null) {
     throw new Meteor.Error('projectNotFound')
   }
 

--- a/imports/api/notes/service.js
+++ b/imports/api/notes/service.js
@@ -45,7 +45,7 @@ Meteor.methods({
         note.lastChange = `${note.author} (${moment(note.date, 'YYYYMMDD').format('YYYY-MM-DD')})`
       }
 
-      if (note.text === undefined) {
+      if (note.text == null) {
         note.text = ''
       } else if (note.text.length > 25) {
         note.text = note.text.substring(0, 25) + ' ...'
@@ -120,7 +120,7 @@ function getExtendedNote (projectId, noteId) {
       }
     })
 
-    if (user !== undefined) {
+    if (user != null) {
       const username = user.profile.firstname + ' ' + user.profile.lastname
       const language = Meteor.user().profile.language
       const dateformat = TAPi18n.__('dateFormat.dateAndTime', '', language)

--- a/imports/api/projects/service.js
+++ b/imports/api/projects/service.js
@@ -50,7 +50,7 @@ Meteor.methods({
       }
     })
 
-    if (project === null) {
+    if (project == null) {
       throw new Meteor.Error('projectNotFound')
     }
 
@@ -63,7 +63,7 @@ Meteor.methods({
   'project.leave': ({ projectId }) => {
     const project = Projects.findOne(projectId, { fields: { 'tags._id': 1 } })
 
-    if (project === null) {
+    if (project == null) {
       throw new Meteor.Error('projectNotFound')
     }
 

--- a/imports/api/publishers/service.availability.js
+++ b/imports/api/publishers/service.availability.js
@@ -17,7 +17,7 @@ function publisherProfileAvailabilityInsert ({ projectId, userId, key }, timeslo
     const publisher = Users.findOne(userId)
     const day = key.split('_').pop().substring(0, 2)
 
-    if (publisher.profile.available === null) {
+    if (publisher.profile.available == null) {
       publisher.profile.available = {}
 
       Users.persistence.update(userId, 'profile.available', {})

--- a/imports/api/publishers/service.crud.js
+++ b/imports/api/publishers/service.crud.js
@@ -71,7 +71,7 @@ function publisherGet ({ projectId, userId }) {
 
   const publisher = getExtendedPublisher(userId, projectId)
 
-  if (publisher !== undefined) {
+  if (publisher != null) {
     publisher.profile.availability = {
       mondays: publisher.profile.availability.mondays.map((x) => { return x.timeslot }).join(', '),
       tuesdays: publisher.profile.availability.tuesdays.map((x) => { return x.timeslot }).join(', '),

--- a/imports/api/publishers/service.vacation.js
+++ b/imports/api/publishers/service.vacation.js
@@ -14,7 +14,7 @@ function publisherProfileVacationInsert ({ projectId, userId }, newVacation) {
 
     // support legacy format
     for (let vacation of vacations) {
-      if (vacation.createdAt === null) {
+      if (vacation.createdAt == null) {
         vacation.start = parseInt(moment(vacation.start, 'YYYYDDD').format('YYYYMMDD'), 10)
         vacation.end = parseInt(moment(vacation.end, 'YYYYDDD').format('YYYYMMDD'), 10)
       }

--- a/imports/api/vessels/service.js
+++ b/imports/api/vessels/service.js
@@ -85,7 +85,7 @@ Meteor.methods({
 
     let visits = Vessels.findOne(vesselId).visits
 
-    if (visits === null) {
+    if (visits == null) {
       visits = []
     }
 
@@ -193,7 +193,7 @@ Meteor.methods({
     }
 
     const visits = Vessels.findOne(vesselId).visits.map((visit) => {
-      if (visit.languageIds === null) {
+      if (visit.languageIds == null) {
         visit.languageIds = []
       }
       if (visit._id === visitId && visit.languageIds.filter((x) => x === languageIds).length === 0) {
@@ -273,7 +273,7 @@ function getExtendedVisit (visit) {
 
   visit.harbor = harbor.name
 
-  if (visit.languageIds === null) {
+  if (visit.languageIds == null) {
     visit.languageIds = []
   } else {
     visit.languageIds = visit.languageIds.map((languageId) => {
@@ -317,7 +317,7 @@ function getExtendedVessel (vesselId) {
 function checkVesselModule (projectId) {
   const project = Projects.findOne(projectId, { fields: { vesselModule: 1 } })
 
-  if (project === null || project.vesselModule !== true) {
+  if (project == null || project.vesselModule !== true) {
     throw new Meteor.Error('projectNotFound')
   }
 

--- a/imports/framework/Forms/DetailsForm/Actions/DetailsForm.Actions.js
+++ b/imports/framework/Forms/DetailsForm/Actions/DetailsForm.Actions.js
@@ -38,7 +38,7 @@ Template.DetailsFormActions.events({
 
     if (confirm(TAPi18n.__(messagePathParts.join('.').replace(/_/g, '.')))) {
       Meteor.call(method, FlowRouter.current().params, (error) => {
-        if (error === null) {
+        if (error == null) {
           FlowRouter.go(FlowRouter.path(route, FlowRouter.current().params))
         } else {
           alert('SERVER ERROR')

--- a/imports/framework/Forms/DetailsForm/DetailsForm.Helpers.js
+++ b/imports/framework/Forms/DetailsForm/DetailsForm.Helpers.js
@@ -7,9 +7,9 @@ import RoleManager from '/imports/framework/Managers/RoleManager'
 import RouteManager from '/imports/framework/Managers/RouteManager'
 
 function loadData (template) {
-  if (template.getMethod !== null) {
+  if (template.getMethod != null) {
     Meteor.call(template.getMethod, FlowRouter.current().params, (e, entity) => {
-      if (e === null) {
+      if (e == null) {
         template.item.set(entity)
         template.noResult.set(false)
         template.isLoading.set(false)
@@ -44,7 +44,7 @@ function getValue (definition, entity) {
 }
 
 function getKey (definition) {
-  if (definition.linkedKey !== null) {
+  if (definition.linkedKey != null) {
     return definition.linkedKey
   }
 
@@ -59,12 +59,12 @@ function hasPermissionToSee (definition) {
   let hasRole = true
   let customFulfilled = true
 
-  if (definition.canSee !== null) {
+  if (definition.canSee != null) {
     const projectId = FlowRouter.getParam('projectId')
     hasRole = RoleManager.hasPermission(projectId, definition.canSee)
   }
 
-  if (definition.custom !== null) {
+  if (definition.custom != null) {
     const template = Template.instance()
     const item = template.item.get()
     customFulfilled = definition.custom(item)
@@ -78,10 +78,10 @@ function defaultClickHandler (e) {
   const key = $e.attr('key')
   const link = $e.attr('link')
 
-  if (link !== null) {
+  if (link != null) {
     let params = FlowRouter.current().params
 
-    if (key !== null) {
+    if (key != null) {
       params.key = key
     }
 

--- a/imports/framework/Forms/DetailsForm/DetailsForm.js
+++ b/imports/framework/Forms/DetailsForm/DetailsForm.js
@@ -60,7 +60,7 @@ Template.DetailsForm.helpers({
     return TAPi18n.__(FlowRouter.getRouteName() + '.sections.' + key.replace(/_/g, '.'))
   },
   getBackgroundColor (section) {
-    return (section.background !== null ? section.background : '')
+    return (section.background != null ? section.background : '')
   },
   isType,
   getItem () {
@@ -92,9 +92,9 @@ Template.DetailsForm.helpers({
     const template = Template.instance()
     const item = template.item.get()
 
-    if (item !== null) {
+    if (item != null) {
       return template.sections.map((section) => {
-        if (section.contents !== null) {
+        if (section.contents != null) {
           section.contents = section.contents.map((content) => {
             if ('canUpdate' in content) {
               if (content.canUpdate === 'author') {
@@ -111,7 +111,7 @@ Template.DetailsForm.helpers({
             return content
           })
         }
-        if (section.actions !== null) {
+        if (section.actions != null) {
           section.actions = section.actions.filter((action) => {
             if ('canSee' in action && action.canSee === 'author') {
               if (item.createdBy !== Meteor.userId()) {
@@ -143,7 +143,7 @@ Template.DetailsForm.helpers({
       const value = entity[field.key]
 
       if (field.type === 'date') {
-        if (value !== null) {
+        if (value != null) {
           const uiFormat = TAPi18n.__('dateFormat.' + field.uiFormat)
           const dbFormat = field.dbFormat
 

--- a/imports/framework/Forms/DetailsForm/EntityArray/DetailsForm.Array.Entity.js
+++ b/imports/framework/Forms/DetailsForm/EntityArray/DetailsForm.Array.Entity.js
@@ -18,7 +18,7 @@ Template.DetailsFormArrayEntity.helpers({
       return TAPi18n.__('language._' + entity._id.toUpperCase())
     }
 
-    if (definition.type === 'date' && value !== null) {
+    if (definition.type === 'date' && value != null) {
       const uiFormat = TAPi18n.__('dateFormat.' + definition.uiFormat)
       const dbFormat = definition.dbFormat
 

--- a/imports/framework/Forms/DetailsForm/Navigation/DetailsForm.Navigation.js
+++ b/imports/framework/Forms/DetailsForm/Navigation/DetailsForm.Navigation.js
@@ -9,7 +9,7 @@ Template.DetailsFormNavigation.helpers({
   getTitle,
   hasBackLink () {
     if (Template.currentData().data) {
-      return Template.currentData().data.backLink !== null
+      return Template.currentData().data.backLink != null
     }
   },
   getBackLink () {
@@ -23,7 +23,7 @@ Template.DetailsFormNavigation.helpers({
     if (Template.currentData().data) {
       const navbarStyle = Template.currentData().data.navbarStyle
 
-      return (navbarStyle !== null ? navbarStyle : '')
+      return (navbarStyle != null ? navbarStyle : '')
     }
   },
   showTitle () {

--- a/imports/framework/Forms/InsertForm/Date/InsertForm.Date.js
+++ b/imports/framework/Forms/InsertForm/Date/InsertForm.Date.js
@@ -23,7 +23,7 @@ Template.InsertFormDate.onCreated(() => {
   template.format = data.format
   template.insertForm = data.parentInstance
 
-  if (data.defaultValue !== null) {
+  if (data.defaultValue != null) {
     if (data.defaultValue === 'today') {
       template.defaultValue = Date()
     } else {
@@ -48,7 +48,7 @@ Template.InsertFormDate.onRendered(() => {
       template.insertForm.setFieldValue(template.key, value)
     })
 
-  if (template.defaultValue !== null) {
+  if (template.defaultValue != null) {
     $datePicker.datepicker('setDate', template.defaultValue)
   }
 })

--- a/imports/framework/Forms/InsertForm/Dropdown/InsertForm.Dropdown.js
+++ b/imports/framework/Forms/InsertForm/Dropdown/InsertForm.Dropdown.js
@@ -17,11 +17,11 @@ Template.InsertFormDropdown.helpers({
   getEntityErrorTranslation,
   isAllowedValues () {
     const template = Template.instance()
-    return template.allowedValues !== null
+    return template.allowedValues != null
   },
   isAllowedKeyValues () {
     const template = Template.instance()
-    return template.allowedKeyValues !== null
+    return template.allowedKeyValues != null
   },
   getItems () {
     const template = Template.instance()
@@ -49,9 +49,9 @@ Template.InsertFormDropdown.onCreated(() => {
   template.allowedKeyValuesMethod = data.allowedKeyValuesMethod
   template.allowedKeyValues = new ReactiveVar(data.allowedKeyValues || [])
 
-  if (template.allowedKeyValuesMethod !== null) {
+  if (template.allowedKeyValuesMethod != null) {
     Meteor.call(template.allowedKeyValuesMethod, FlowRouter.current().params, (e, keyValues) => {
-      if (e === null) {
+      if (e == null) {
         template.allowedKeyValues.set(keyValues)
       } else {
         alert('SERVER ERROR')

--- a/imports/framework/Forms/InsertForm/InsertForm.js
+++ b/imports/framework/Forms/InsertForm/InsertForm.js
@@ -31,7 +31,7 @@ Template.InsertForm.helpers({
     return FlowRouter.path(Template.instance().backLink.get(), FlowRouter.current().params)
   },
   getSearchTranslation () {
-    if (FlowRouter.getParam('key') !== null) {
+    if (FlowRouter.getParam('key') != null) {
       const key = FlowRouter.getParam('key').replace(/_/g, '.') + 'Values'
 
       let routeNameParts = FlowRouter.getRouteName().split('.')
@@ -48,7 +48,7 @@ Template.InsertForm.helpers({
     const template = Template.instance()
     const activeFieldKey = template.activeField.get()
 
-    if (activeFieldKey !== null) {
+    if (activeFieldKey != null) {
       const activeField = template.fields.filter((field) => {
         return field.key === activeFieldKey
       })[0]
@@ -104,7 +104,7 @@ Template.InsertForm.helpers({
       }
     })
 
-    if (template.entity[inputData.key] !== null &&
+    if (template.entity[inputData.key] != null &&
       template.entity[inputData.key] !== '') {
       inputData.value = template.entity[inputData.key]
     }
@@ -129,9 +129,9 @@ Template.InsertForm.helpers({
         if (field.type === 'date') {
           inputData.format = field.format
         }
-        if (template.entity[field.key] !== null) {
+        if (template.entity[field.key] != null) {
           inputData.value = template.entity[field.key]
-        } else if (field.defaultValue !== null) {
+        } else if (field.defaultValue != null) {
           inputData.value = field.defaultValue
         }
         return true
@@ -145,7 +145,7 @@ Template.InsertForm.helpers({
   },
   isRequired () {
     const data = Template.currentData().data
-    if (data.required !== null) {
+    if (data.required != null) {
       return data.required
     }
     return false
@@ -188,7 +188,7 @@ Template.InsertForm.onRendered(() => {
 Template.InsertForm.events({
   'click .navbar-back': function (e) {
     const template = Template.instance()
-    if (template.activeField.get() !== null) {
+    if (template.activeField.get() != null) {
       e.preventDefault()
       e.stopPropagation()
 
@@ -223,13 +223,13 @@ Template.InsertForm.events({
     Meteor.call(FlowRouter.getRouteName(), FlowRouter.current().params, template.entity, (error, entityId) => {
       template.isSaving.set(false)
 
-      if (error !== null) {
+      if (error != null) {
         if (error.error.error === 'validation-error') {
           let errors = []
 
-          if (error.error.reason !== null && typeof e.error.reason === 'object') {
+          if (error.error.reason != null && typeof e.error.reason === 'object') {
             errors = errors.concat(e.error.reason)
-          } else if (error.error.details !== null) {
+          } else if (error.error.details != null) {
             errors = errors.concat(error.error.details)
           }
 
@@ -271,7 +271,7 @@ function getRegexLastIndexOf (string, regex) {
   let nextStop = 0
   let result
 
-  while ((result = regex.exec(stringToWorkWith)) !== null) {
+  while ((result = regex.exec(stringToWorkWith)) != null) {
     lastIndexOf = result.index
     regex.lastIndex = ++nextStop
   }

--- a/imports/framework/Forms/InsertForm/Link/InsertForm.Link.js
+++ b/imports/framework/Forms/InsertForm/Link/InsertForm.Link.js
@@ -16,13 +16,13 @@ Template.InsertFormLink.helpers({
   getValue () {
     const template = Template.instance()
 
-    if (template.displayValue !== null) {
+    if (template.displayValue != null) {
       return template.displayValue
     }
     let value = 'placeholder'
     const data = Template.currentData().data
 
-    if (data.value !== null) {
+    if (data.value != null) {
       value = data.value
     }
 
@@ -42,7 +42,7 @@ Template.InsertFormLink.onCreated(() => {
   template.key = data.key
   template.insertForm = data.parentInstance
 
-  if (data.allowedKeyValues !== null && data.value !== null) {
+  if (data.allowedKeyValues != null && data.value != null) {
     template.displayValue = data.allowedKeyValues.filter((keyValue) => {
       return keyValue.key === data.value
     })[0].value

--- a/imports/framework/Forms/InsertForm/Password/InsertForm.Password.js
+++ b/imports/framework/Forms/InsertForm/Password/InsertForm.Password.js
@@ -13,7 +13,7 @@ Template.InsertFormPassword.helpers({
   getEntityErrorTranslation,
   getValue () {
     const data = Template.currentData().data
-    if (data.value !== null) {
+    if (data.value != null) {
       return data.value
     }
     return ''

--- a/imports/framework/Forms/InsertForm/Picker/InsertForm.Picker.js
+++ b/imports/framework/Forms/InsertForm/Picker/InsertForm.Picker.js
@@ -16,11 +16,11 @@ Template.InsertFormPicker.helpers({
   getEntityErrorTranslation,
   isAllowedValues () {
     const template = Template.instance()
-    return template.allowedValues !== null
+    return template.allowedValues != null
   },
   isAllowedKeyValues () {
     const template = Template.instance()
-    return template.allowedKeyValues.get() !== null
+    return template.allowedKeyValues.get() != null
   },
   getItems () {
     const template = Template.instance()
@@ -85,9 +85,9 @@ Template.InsertFormPicker.onCreated(() => {
   template.allowedKeyValuesMethod = data.allowedKeyValuesMethod
   template.allowedKeyValues = new ReactiveVar(data.allowedKeyValues)
 
-  if (template.allowedKeyValuesMethod !== null) {
+  if (template.allowedKeyValuesMethod != null) {
     Meteor.call(template.allowedKeyValuesMethod, FlowRouter.current().params, (e, keyValues) => {
-      if (e === null) {
+      if (e == null) {
         template.allowedKeyValues.set(keyValues)
       } else {
         alert('SERVER ERROR')

--- a/imports/framework/Forms/InsertForm/Text/InsertForm.Text.js
+++ b/imports/framework/Forms/InsertForm/Text/InsertForm.Text.js
@@ -13,7 +13,7 @@ Template.InsertFormText.helpers({
   getEntityErrorTranslation,
   getValue () {
     const data = Template.currentData().data
-    if (data.value !== null) {
+    if (data.value != null) {
       return data.value
     }
     return ''

--- a/imports/framework/Forms/InsertForm/Textbox/InsertForm.Textbox.js
+++ b/imports/framework/Forms/InsertForm/Textbox/InsertForm.Textbox.js
@@ -14,7 +14,7 @@ Template.InsertFormTextbox.helpers({
   getEntityErrorTranslation,
   getValue () {
     const data = Template.currentData().data
-    if (data.value !== null) {
+    if (data.value != null) {
       return data.value
     }
     return ''

--- a/imports/framework/Forms/SearchForm/SearchForm.Helpers.js
+++ b/imports/framework/Forms/SearchForm/SearchForm.Helpers.js
@@ -81,11 +81,11 @@ function doSearch (template, retrieveAllResults = false) {
   template.resultsShown.set(params.limit)
 
   Meteor.call(routeName, params, (e, r) => {
-    if (e !== null) {
+    if (e != null) {
       alert(e); return
     }
 
-    if (r !== null) {
+    if (r != null) {
       template.items.set(r.items)
       template.itemCount.set(r.total)
       template.isLoading.set(false)

--- a/imports/framework/Forms/UpdateForm/Date/UpdateForm.Date.js
+++ b/imports/framework/Forms/UpdateForm/Date/UpdateForm.Date.js
@@ -23,7 +23,7 @@ Template.UpdateFormDate.onCreated(() => {
   template.format = data.format
   template.updateForm = data.parentInstance
 
-  if (template.valueRaw !== null && template.valueRaw === 'today') {
+  if (template.valueRaw != null && template.valueRaw === 'today') {
     template.valueRaw = moment(Date()).format(template.format)
   }
 })
@@ -51,7 +51,7 @@ Template.UpdateFormDate.onRendered(() => {
       }
     })
 
-  if (template.valueRaw !== null && template.valueRaw !== '') {
+  if (template.valueRaw != null && template.valueRaw !== '') {
     $datePicker.datepicker('setDate', moment(template.valueRaw, template.format).toDate())
   }
 

--- a/imports/framework/Forms/UpdateForm/Dropdown/UpdateForm.Dropdown.js
+++ b/imports/framework/Forms/UpdateForm/Dropdown/UpdateForm.Dropdown.js
@@ -17,11 +17,11 @@ Template.UpdateFormDropdown.helpers({
   getEntityErrorTranslation,
   isAllowedValues () {
     const template = Template.instance()
-    return template.allowedValues !== null
+    return template.allowedValues != null
   },
   isAllowedKeyValues () {
     const template = Template.instance()
-    return template.allowedKeyValuesMethod !== null
+    return template.allowedKeyValuesMethod != null
   },
   getItems () {
     const template = Template.instance()
@@ -47,9 +47,9 @@ Template.UpdateFormDropdown.onCreated(() => {
   template.allowedKeyValuesMethod = data.allowedKeyValuesMethod
   template.allowedKeyValues = new ReactiveVar([])
 
-  if (template.allowedKeyValuesMethod !== null) {
+  if (template.allowedKeyValuesMethod != null) {
     Meteor.call(template.allowedKeyValuesMethod, FlowRouter.current().params, (e, keyValues) => {
-      if (e === null) {
+      if (e == null) {
         template.allowedKeyValues.set(keyValues)
       } else {
         alert('SERVER ERROR')

--- a/imports/framework/Forms/UpdateForm/Picker/UpdateForm.Picker.js
+++ b/imports/framework/Forms/UpdateForm/Picker/UpdateForm.Picker.js
@@ -16,11 +16,11 @@ Template.UpdateFormPicker.helpers({
   getEntityErrorTranslation,
   isAllowedValues () {
     const template = Template.instance()
-    return template.allowedValues !== null
+    return template.allowedValues != null
   },
   isAllowedKeyValues () {
     const template = Template.instance()
-    return template.allowedKeyValuesMethod !== null
+    return template.allowedKeyValuesMethod != null
   },
   getItems () {
     const template = Template.instance()
@@ -74,9 +74,9 @@ Template.UpdateFormPicker.onCreated(() => {
   template.allowedKeyValuesMethod = data.allowedKeyValuesMethod
   template.allowedKeyValues = new ReactiveVar([])
 
-  if (template.allowedKeyValuesMethod !== null) {
+  if (template.allowedKeyValuesMethod != null) {
     Meteor.call(template.allowedKeyValuesMethod, FlowRouter.current().params, (e, keyValues) => {
-      if (e === null) {
+      if (e == null) {
         template.allowedKeyValues.set(keyValues)
       } else {
         alert('SERVER ERROR')

--- a/imports/framework/Forms/UpdateForm/UpdateForm.js
+++ b/imports/framework/Forms/UpdateForm/UpdateForm.js
@@ -30,7 +30,7 @@ Template.UpdateForm.helpers({
     return FlowRouter.path(Template.instance().backLink.get(), FlowRouter.current().params)
   },
   getSearchTranslation () {
-    if (FlowRouter.getParam('key') !== null) {
+    if (FlowRouter.getParam('key') != null) {
       const key = FlowRouter.getParam('key').replace(/_/g, '.') + 'Values'
 
       let routeNameParts = FlowRouter.getRouteName().split('.')
@@ -44,7 +44,7 @@ Template.UpdateForm.helpers({
     }
   },
   isSearchEnabled () {
-    return Template.instance().inputData.get().search === true && FlowRouter.getParam('key') !== null
+    return Template.instance().inputData.get().search === true && FlowRouter.getParam('key') != null
   },
   isReady () {
     return !Template.instance().isLoading.get() && !Template.instance().noResult.get()
@@ -73,7 +73,7 @@ Template.UpdateForm.onCreated(() => {
     const key = FlowRouter.getParam('key')
 
     Meteor.call(routeName, params, key, value, (e) => {
-      if (e !== null) {
+      if (e != null) {
         if (e.error.error === 'validation-error' && e.error.reason.length > 0) {
           let inputData = template.inputData.get()
           inputData.error = e.error.reason[0].type
@@ -96,7 +96,7 @@ Template.UpdateForm.onRendered(() => {
   template.inputData.set({ parentInstance: template })
 
   Meteor.call(data.getMethod, FlowRouter.current().params, (e, value) => {
-    if (e === null) {
+    if (e == null) {
       let inputData = template.inputData.get()
       inputData.value = value
       template.inputData.set(inputData)

--- a/imports/framework/Functions/Checks.js
+++ b/imports/framework/Functions/Checks.js
@@ -16,7 +16,7 @@ const Checks = {
         }
       })
 
-      if (user === null) {
+      if (user == null) {
         throw new Meteor.Error('invalidUserId')
       }
     }
@@ -29,7 +29,7 @@ const Checks = {
         }
       })
 
-      if (shift === null) {
+      if (shift == null) {
         throw new Meteor.Error('invalidShiftId')
       }
     },
@@ -53,7 +53,7 @@ const Checks = {
         }
       })
 
-      if (week === null) {
+      if (week == null) {
         throw new Meteor.Error('invalidWeek')
       }
     }
@@ -66,7 +66,7 @@ const Checks = {
         }
       })
 
-      if (project === null) {
+      if (project == null) {
         throw new Meteor.Error('invalidProject')
       }
     },
@@ -97,7 +97,7 @@ const Checks = {
         }
       })
 
-      if (project === null) {
+      if (project == null) {
         throw new Meteor.Error('invalidTag')
       }
     },
@@ -128,7 +128,7 @@ const Checks = {
         'teams._id': teamId
       })
 
-      if (project === null) {
+      if (project == null) {
         throw new Meteor.Error('invalidTeam')
       }
     }
@@ -140,7 +140,7 @@ const Checks = {
         'meetings._id': meetingPointId
       })
 
-      if (project === null) {
+      if (project == null) {
         throw new Meteor.Error('invalidMeetingPoint')
       }
     }

--- a/imports/framework/Functions/Security.js
+++ b/imports/framework/Functions/Security.js
@@ -6,7 +6,7 @@ import Permissions from '/imports/framework/Constants/Permissions'
 function checkPermissions (projectId, userId = null) {
   const project = Projects.findOne(projectId, { fields: { _id: 1 } })
 
-  if (project === null) {
+  if (project == null) {
     throw new Meteor.Error('projectNotFound')
   }
 
@@ -14,7 +14,7 @@ function checkPermissions (projectId, userId = null) {
     throw new Meteor.Error('youAreNotProjectAdmin')
   }
 
-  if (userId !== null && !Roles.userIsInRole(userId, Permissions.member, projectId)) {
+  if (userId != null && !Roles.userIsInRole(userId, Permissions.member, projectId)) {
     throw new Meteor.Error('userIsNotProjectMember')
   }
 }

--- a/imports/framework/Helpers/Helpers.js
+++ b/imports/framework/Helpers/Helpers.js
@@ -11,13 +11,13 @@ function getTitle () {
 }
 
 function getEntityTranslation (key, suffix) {
-  if (key === null) {
+  if (key == null) {
     key = FlowRouter.getParam('key')
   }
 
   const attributeParts = [key]
 
-  if (suffix !== null && typeof (suffix) === 'string') {
+  if (suffix != null && typeof (suffix) === 'string') {
     attributeParts.push(suffix)
   }
 

--- a/imports/framework/Managers/RouteManager.Helpers.js
+++ b/imports/framework/Managers/RouteManager.Helpers.js
@@ -30,7 +30,7 @@ const doIfLoggedIn = function (whatToDo, elseToDo) {
       BlazeLayout.render('blankLayout', { content: 'loading' })
     } else if (Meteor.userId()) {
       whatToDo()
-    } else if (elseToDo !== null) {
+    } else if (elseToDo != null) {
       elseToDo()
     } else {
       BlazeLayout.render('blankLayout', { content: 'login' })

--- a/imports/startup/client/language.js
+++ b/imports/startup/client/language.js
@@ -14,7 +14,7 @@ function setLanguageOnAuth () {
   moment.locale('en') // default
 
   Tracker.autorun((tracker) => {
-    if (Meteor.user() !== null) {
+    if (Meteor.user() != null) {
       tracker.stop()
 
       const language = FlowRouter.current().params.language

--- a/imports/ui/calendar/calendar.js
+++ b/imports/ui/calendar/calendar.js
@@ -47,7 +47,7 @@ Template.calendar.onRendered(() => {
   let month = FlowRouter.getParam('month')
   let day = FlowRouter.getParam('day')
 
-  if (year === null || month === null || day === null) {
+  if (year == null || month == null || day == null) {
     template.setDate(new Date())
   } else {
     template.setDate(new Date(year, month - 1, day))


### PR DESCRIPTION
staging throws errors permanently because the `===` comparison makes a distinction between null and undefined, so undefined !== null.
This reinstates the previous check that is still valid by standard's rules.