### PR TITLE
Update manifest.json to display the correct name

### DIFF
--- a/public/favicon/manifest.json
+++ b/public/favicon/manifest.json
@@ -1,5 +1,5 @@
 {
-	"name": "asdf",
+	"name": "JW Management",
 	"icons": [
 		{
 			"src": "\/android-chrome-36x36.png?v=PYYdqp0QgP",


### PR DESCRIPTION
For users that want to add the webpage to their homescreens or desktops, it would suggest `asdf` as the title. Fixed now.