### PR TITLE
Added English (Australia) option to Framework Languages. 

### DIFF
--- a/both/i18n/de/language.de.i18n.yml
+++ b/both/i18n/de/language.de.i18n.yml
@@ -7,6 +7,7 @@ language:
     languageValues:
       de: Deutsch
       en: Englisch
+      en-AU: Englisch (Australia)
       fi: Finnisch
       fr: Französisch
       hu: Ungarisch
@@ -18,6 +19,7 @@ language:
       zh-CN: Chinesisch (Vereinfacht) (teilweise)
   _de: Deutsch
   _en: Englisch
+  _en-AU: Englisch (Australia)
   _fi: Finnisch
   _fr: Französisch
   _hu: Ungarisch

--- a/both/i18n/en-AU/calendar.en-AU.i18n.yml
+++ b/both/i18n/en-AU/calendar.en-AU.i18n.yml
@@ -1,0 +1,3 @@
+calendar:
+  teamleadNeeded: TL needed
+  noShifts: No shifts

--- a/both/i18n/en-AU/dashboard.en-AU.i18n.yml
+++ b/both/i18n/en-AU/dashboard.en-AU.i18n.yml
@@ -1,0 +1,113 @@
+dashboard:
+
+  # old dashboard
+  loadingProjects: Loading Projects...
+  projects: My Projects
+  noProjects: You're not participating in any project
+  loadingShifts: Loading Shifts...
+  shifts: My Shifts
+  noShifts: You currently have no shifts
+  news: Current News
+  noNews: No News
+  newsFrom: Last Change
+  editNews: Edit the news
+  changeNews: Change the news
+  cancelNews: Cancel editing
+  understaffed: Understaffed
+  understaffedMore: Show more understaffed shifts
+  missing: Missing Shift Report
+  missing_plural: Missing Shift Reports
+  approved: Approved Request
+  approved_plural: Approved Request
+  pending: Pending Request
+  pending_plural: Pending Requests
+  declined: Declined Request
+  declined_plural: Declined Requests
+  marked: Understaffed Shift
+  marked_plural: Understaffed Shifts
+  participant: Shift Participant
+  participant_plural: Shift Participants
+  showOlder: Show older shifts too
+  showAll: Show all
+  calendar: Calendar
+
+  # new dashboard
+  myProjects:
+    details:
+      sections:
+        myProjects: My projects
+  missingShiftReports:
+    details:
+      sections:
+        missingShiftReports: Missing shift reports
+  upcomingShifts:
+    details:
+      sections:
+        upcomingShifts: Upcoming shifts
+  pendingRequests:
+    details:
+      sections:
+        pendingRequests: Pending requests
+  olderShifts:
+    details:
+      sections:
+        olderShifts: Previously done shifts
+  entity:
+    profile: Profile
+    language: Language
+    projects: Projects
+    users: Users
+    shift:
+      tag: Tag
+      date: Date
+      start: Begin
+      end: End
+    logout: Sign out
+
+    # old dashboard
+    newDashboard: To the new dashboard
+    newDashboardDescription: Good news! We redesigned the dashboard for you. It should especially be handy on mobile devices. We hope you like it! If anything doesn't work for you, please tell your project coordinators - they'll inform us.
+    oldDashboard: To the old dashboard
+    onlineUsers: Currently online users
+    myProjects:
+      seeAllItems: See one more project
+      seeAllItems_plural: See the other __count__ projects
+    missingShiftReports:
+      shift:
+        tag: Tag
+        date: Date
+        start: Begin
+        end: End
+      seeAllItems: See one more missing shift report
+      seeAllItems_plural: See the other __count__ missing shift reports
+    upcomingShifts:
+      shift:
+        tag: Tag
+        date: Date
+        start: Begin
+        end: End
+      seeAllItems: See one more upcoming shift
+      seeAllItems_plural: See the other __count__ upcoming shifts
+    pendingRequests:
+      link: See all my pending requests
+      shift:
+        tag: Tag
+        date: Date
+        start: Begin
+        end: End
+    olderShifts:
+      link: See all my previously done shifts
+      shift:
+        tag: Tag
+        date: Date
+        start: Begin
+        end: End
+    startProject: New project
+  details:
+    sections:
+      myProjects: My projects
+      missingShiftReports: Missing shift reports
+      upcomingShifts: My upcoming shifts
+      otherShifts: Other shifts
+      administration: Administration
+      account: Account

--- a/both/i18n/en-AU/errors.en-AU.i18n.yml
+++ b/both/i18n/en-AU/errors.en-AU.i18n.yml
@@ -1,0 +1,13 @@
+error:
+  nameRequired: Please enter the name of this vessel
+  callsignUnique: A vessel with this call sign is already existing
+  eniUnique: A vessel with this ENI number is already existing
+  imoUnique: A vessel with this IMO number is already existing
+  mmsiUnique: A vessel with this MMSI number is already existing
+  missingField: Please fill out all fields
+  incorrectPassword: This password seems to be incorrect
+  noAccountFound: No account with this username or email could be found
+  multipleAccountsFound: There are multiple accounts with this email. Please use the username
+  passwordsDoNotMatch: The passwords do not match
+  passwordTooShort: The password has to have at least 8 characters
+  403: This username already exists

--- a/both/i18n/en-AU/framework.en-AU.i18n.yml
+++ b/both/i18n/en-AU/framework.en-AU.i18n.yml
@@ -1,0 +1,23 @@
+searchForm:
+  loading: Loading
+  noResults: No results
+  xResults: %s result
+  xResults_plural: %s results
+  showingTheFirstX: Showing the first %s
+  showingAll: ''
+  showingAll_plural: Showing all
+  showAll: Show all %s
+validation:
+  required: This field is required
+  unique: There already is a record with this value
+  minString8: The password has to be at least 8 characters long
+  passwordMismatch: The passwords do not match
+  hasToBeBigger: This value has to be bigger
+  regEx: This is not a valid email address
+detailsForm:
+  yes: Yes
+  no: No
+dateFormat:
+  date: DD/MM/YYYY
+  dateAndTime: DD/MM/YYYY hh:mm a
+  time: h:mm a

--- a/both/i18n/en-AU/language.en-AU.i18n.yml
+++ b/both/i18n/en-AU/language.en-AU.i18n.yml
@@ -7,7 +7,7 @@ language:
     languageValues:
       de: German
       en: English
-      en-AU: English (Australia)
+      au: English (Australia)
       fi: Finnish
       fr: French
       hu: Hungarian
@@ -19,7 +19,7 @@ language:
       zh-CN: Chinese (Simplified) (partially)
   _de: German
   _en: English
-  _en-AU: English (Australia)
+  _au: English (Australia)
   _fi: Finnish
   _fr: French
   _hu: Hungarian
@@ -48,7 +48,7 @@ language:
   _DAR: Dari
   _DGS: German Sign Language
   _E: English
-  _EA: English Australia
+  _E-AU: English (Australia)
   _ED: Edo
   _EDF: English edition for the Deaf
   _EW: Ewe

--- a/both/i18n/en-AU/mail.en-AU.i18n.yml
+++ b/both/i18n/en-AU/mail.en-AU.i18n.yml
@@ -1,0 +1,71 @@
+mail:
+  footer: This is an automated mail. We don't expect an answer to it.
+  link: Open JW Management
+  accountCreated:
+    subject: JW Management Account Created!
+    headline: Welcome!
+    hello: Hello
+    text1: We would like to tell you that we have created an account for you in JW Management. You can set your personal username and password by clicking on the button below.
+    text2: In case of problems please feel free to contact us.<br>We wish you much joy using JW Management.<br>Your brothers from JW Management
+    button: Let's Go!
+  teamCancellation:
+    subject: Team cancelled
+    headline: Team has been cancelled.
+    hello: Hello
+    text: Unfortunately we had to tell you that your team assignment on <b>__date__</b> at <b>__time__</b> o'clock was <u>cancelled</u>.
+    missingParticipant: A participant is missing. If there are enough participants the team can take place again.
+  confirmation:
+    subject: New Request Approved
+    headline: Your Request was approved!
+    hello: Hello
+    text1: Your request for the following shift was approved:
+    datetime: __date__ from __time__ o'clock
+  declined:
+    subject: Request not considered
+    headline: Request was not considered
+    hello: Hello
+    text1: Unfortunately your request for the following shift could not be considered:
+    text2: Thank you very much for your request!
+    datetime: __date__ from __time__ o'clock
+  reversal:
+    subject: Reversal
+    hello: Hello
+    text1: You were removed from the following team:
+    datetime: __date__ from __time__ o'clock
+  teamUpdate:
+    subject: Team changed
+    _changed: changed.
+    changed:
+      participant: A participant
+      time: The time
+      location: The location
+      leader: The team leader
+    hello: Hello
+    text1: You are marked as team member or leader so we would like to inform you about changes in your team.
+    text2: Here is the current team configuration
+    datetime: __date__ from __time__ o'clock
+  joinProject:
+    subject: Joined Project
+    headline: You were added to a project
+    hello: Hello
+    text1: You were invited to the following Project
+    text2: You find this project now on your dashboard at "My Projects".<br>Have a good time!
+  understaffed:
+    subject: Team understaffed
+    headline: Team is understaffed
+    hello: Hello
+    text1: the following Team is understaffed and needs a
+    text2: Please have a look whether you can help this team.
+    datetime: __date__ from __time__ o'clock
+  toOrga:
+    hello: Hello Organisation Team
+    subject:
+      teamCancel: Team cancelled
+    text:
+      teamCancel: The team <b>"__team__"</b> on <b>__date__</b> at <b>__time__</b> o'clock were <u>cancelled</u>.
+  resetPassword:
+    subject: Reset Password
+    headline: Reset your Password
+    text1: Hello,<br>Please click the following button to set a new password:
+    button: Reset Password
+    text2: <p>Useful hints for secure password generation can be found in <a href="http://wol.jw.org/en/wol/d/r1/lp-e/102001451">g01 6/22 p. 31</a></p><p>If you didn't request a password reset, feel free to delete this email.</p>

--- a/both/i18n/en-AU/misc.en-AU.i18n.yml
+++ b/both/i18n/en-AU/misc.en-AU.i18n.yml
@@ -1,0 +1,80 @@
+input:
+  username: Username
+  usernameOrEmail: Username or Email address
+  firstname: First name
+  lastname: Surname
+  email: Email address
+  telefon: Phone
+  congregation: Congregation
+  languages: Languages
+  gender: Gender
+  privilegeOfService: Privilege of Service
+  privilegeOfMinistry: Congregation Assignment
+  password: Password
+  passwordRepeat: Repeat password
+  newPassword: New password
+  newPasswordRepeat: Repeat new password
+role:
+  role: Role
+  admin: Project manager
+  shiftScheduler: Shift scheduler
+  shiftAdmin: Shift manager
+  storeAdmin: Store manager
+  member: Member
+  teamleader: Team leader
+  substituteTeamleader: Substitute team leader
+  participant: Participant
+  nothing: None
+  noPermission: No permission
+permissions:
+  notAdmin: This user is not a project manager
+  notShiftScheduler: This user is not a shift scheduler
+  notShiftAdmin: This user is not a shift manager
+  notStoreAdmin: This user is not a store manager
+  notProjectParticipant: This user is not participating in the given project
+  notTeamleader: This user is not a team leader
+  notTagParticipant: This user is not participating in the given tag
+  notTeamParticipant: This user is not participating in the given team
+time:
+  start: Start
+  end: End
+  suffix: hours
+  years: years
+  to: to
+scheduling:
+  name: Scheduling
+  direct: Approve immediately
+  manual: Approve manually
+password:
+  tooShort: Password must be at least 8 characters long
+  notMatching: The passwords do not match!
+weekdays:
+  _mo: Monday
+  _tu: Tuesday
+  _we: Wednesday
+  _th: Thursday
+  _fr: Friday
+  _sa: Saturday
+  _su: Sunday
+intervals:
+  m: Manually
+  every: Every week
+  even: Every other week (even)
+  odd: Every other week (odd)
+privileges:
+  auxiliary: AP
+  regular: RP
+  special: SP
+  circuit: CO
+  bethelite: BT
+  ldc: LDC
+  coordinator: CBE
+  secretary: SEC
+  serviceOverseer: SO
+  elder: E
+  servant: S
+  publisher: P
+period:
+  d: D
+  w: W
+  4w: 4W

--- a/both/i18n/en-AU/modals.en-AU.i18n.yml
+++ b/both/i18n/en-AU/modals.en-AU.i18n.yml
@@ -1,0 +1,241 @@
+modal:
+  close: Close
+  addParticipant:
+    title: Add participant
+    description: Please choose the publisher you want to add to this shift.
+    submit: Add
+    alreadyRequested: This user has already requested participation
+    alreadyParticipating: This user is already participating
+    select: Select Publisher
+    available: available
+    callable: callable in short term
+  addUser:
+    title: Create a new user
+    action: Create user
+    upload: Upload File
+    helpText: The username should be short and memorable. Combinations of the user's first and last names are known to suit well.<br>Example: "JohnD" or "JDoe"
+    invite: Invite %s (%s)
+    existingAccounts: Existing Accounts
+  addVessel:
+    title: Add a vessel
+    action: Add vessel
+  addWeek:
+    title: Create new week
+    noTemplate: Please define a template first
+    defineTemplate: Define template
+    action: Create week
+    text:
+      top: Choose a week, that the template week will get applied to:
+      bottom: Choose the template week:
+  cancelTeam:
+    title: Cancel team
+    text: Describe why this team has to be cancelled. All participants will get this message via the cancellation mail.
+    action: Cancel team
+  copyShift:
+    title: Copy shift
+    text: Just select the days to which you want to copy this shift.
+    action: Copy shift
+  editPermissions:
+    title: Manage %s's permissions
+    projectPermissions: Project permissions
+    projectRole: Project role
+    tagPermissions: Tag roles
+    explanations: Explanations
+    helpText:
+      admin: The project manager role is the highest authorization level. A project manager is allowed to control everything. For every project there has to be at least one project manager.
+      shiftScheduler: The shift scheduler has the permissions of a participant but can also schedule shifts.
+      shiftAdmin: The shift manager has the permissions of a shift scheduler but can also create, change and delete shifts.
+      storeAdmin: The store manager has the permissions of a participant but can also view the shift reports and edit the store.
+      member: The member is the most basic role. He is allowed to view the Information Center.
+      teamleader: The team leader once assigned by a project manager to a certain tag is then in charge of the shift team report for said tag.
+      substituteTeamleader: A substitute team leader has the same permissions as a normal team leader. But if the system shall schedule automatically, it will always prefer the request of a normal team leader if there is one.
+      participant: The participant can see and request shifts of assigned tags.
+      nothing: With "None" the user cannot see or request shifts of this tag. Neither can he be scheduled into a shift.
+  editShift:
+    title: Edit shift information
+    mainData: Main Details
+    tag: Tag
+    team: Team
+    teams: Teams assigned to this shift
+    helpText:
+      tag: Set this shift tag. All users with permissions on this tag can view the shift.
+      scheduling: With 'approve immediately' requests will be approved automatically, when the minimum participant limit for the next team is reached.
+    addTeam: Add a new team
+    teamMin: Minimum participants:
+    teamMax: Maximum participants:
+    teamStart: Start:
+    teamEnd: End:
+    teamPlace: Place:
+    removeTeam: Remove this team
+    noMeeting: No Meeting
+    action: Action:
+    delete: Delete
+    switch: Schedule shift
+    copyShift: Copy shift
+  editTeamPicture:
+    title: Change team picture
+    currentPicture: Current Picture:
+    hints: This picture will probably be displayed larger for the publisher.
+    noPictureUploaded: You have not yet uploaded any picture
+    upload: Upload
+    delete: Delete
+  editMeetingPicture:
+    title: Change meeting point picture
+    currentPicture: Current Picture:
+    hints: This picture will probably be displayed larger for the publisher.
+    noPictureUploaded: You have not yet uploaded any picture
+    upload: Upload
+    delete: Delete
+  editVessel:
+    title: Edit vessel
+    action: Save changes
+  inviteUser:
+    title: Invite new Publishers
+    key: <span class="text-warning">Orange name</span> means that the user is already invited.
+    selectAll: Select All
+    noUsers: No new publishers found
+    invite: Invite
+  position:
+    title: Mark position with left mouse click
+  shift:
+    clickToEnlarge: Click the image to enlarge it
+    openLink: View linked information
+    meetingAt: Meeting point at
+    collapseTeam: Collapse team information and meeting points
+    expandTeam: Expand team information and meeting points
+    noParticipants: No participants
+    requestTeam: Request participation
+    requestTeamAgain: Request participation again
+    requests: Requests
+    cancelTeam: Cancel team
+    cancelRequest: Cancel request
+    cancelParticipation: Cancel participation
+    addParticipant: Add participant
+    unknownAge: Unknown age
+    closedTeam: This team is closed. You can't request participation.
+    maximumReached: Maximum limit for team participants has already been reached
+    noPermission: You don't have the permission to schedule users
+    noTeamleader: This user doesn't have permission to be a team leader
+    alreadyTeamleader: This user is already a team leader
+    openTeam: Open team
+    closeTeam: Close team
+    sendUnderstaffed: Send understaffed mail
+    switch: Edit shift
+    existingTeamleaders: Team leader exists
+    noExistingTeamleader: Team leader missing
+    notTeamleader: No team leader
+    selected: Selected:
+    of: of
+    approveSelected: Approve selected
+    declineSelected: Decline selected
+    report: Report
+    allocations: Shifts
+    thisWeek: this week
+    lastDays: last %s days
+  shiftReport:
+    title: Report
+    teamleader: Team leader
+    substituteTeamleader: Substitute team leader
+    publications: Publications
+    occurrences: Occurrences
+    store: Store
+    experiences: Experiences
+    present: Present
+    sick: Sick
+    missing: Missing
+    name: Name
+    language: Language
+    count: Count
+    action: Action
+    noPublications: No publications here
+    select_publication: Select a publication
+    selectPublicationFirst: Please select a publication first
+    addItem: Add this publication
+    removeItem: Remove this publication
+    texts: Bible Texts
+    speaks: Conversations
+    videos: Shown Videos
+    website: Website shown
+    returnVisits: Return Visits
+    bibleStudies: Bible Studies
+    time: Hours of Service
+    trolleysFilled: Trolleys were filled
+    neatnessLast: Trolley condition after last Shift
+    bad: Bad
+    normal: Normal
+    good: Good
+    yes: Yes
+    no: No
+    expRoute: Route
+    expGood: Nice Experiences
+    expProblems: Problems / Difficulties
+    date: Date
+    toShift: To the shift
+    pages:
+      publisher: Publisher page
+      items: Placed publications page
+      occurrences: Happened occurrences
+      store: About the store room
+      experiences: Your experiences
+      prevPage: Go to the previous page
+      nextPage: Go to the next page
+      finish: Finish this report
+  shift:
+    collapseTeam: Collapse Route and Meeting points
+    expandTeam: Expand Route and Meeting point
+    noParticipants: No participants
+    requestTeam: Request participation
+    requestTeamAgain: Request participation again
+    requests: Requests
+    cancelRequest: Cancel request
+    cancelParticipation: Cancel participation
+    addParticipant: Add participant
+    unknownAge: Unknown age
+    closedTeam: This team is closed. You can't request participation.
+    maximumReached: Maximum limit for team participants was already reached
+    noPermission: You don't have permission to schedule users
+    noTeamleader: This user doesn't have permission to be a team leader
+    alreadyTeamleader: This user is already team leader
+    openTeam: Open team
+    closeTeam: Close team
+    switch: Edit shift
+    existingTeamleaders: Team leader exists
+    noExistingTeamleader: Team leader missing
+  position:
+    title: Mark position with left mouse click
+  route:
+    title: Create/edit route
+    routeMarkers: Route marker
+    addRouteMarkers: Click on the map to add a new route marker
+  addParticipant:
+    title: Add participant
+    noUsers: No available users found
+    description: Please choose the publisher you want to add to this shift.
+    submit: Add
+    alreadyRequested: This user has already requested participation
+    alreadyParticipating: This user is already participating
+    available_users: Available Publisher
+    all_users: Other Publisher
+    select: Select Publisher
+  inviteUser:
+    title: Invite new Publishers
+    key: <span class="text-warning">Orange name</span> means user is already invited.
+    selectAll: Select All
+    noUsers: No new Publishers found
+    invite: Invite
+  uploadUserFile:
+    title: User-File upload
+    helpText: Order of personal data (* fields are required): <br> Email*, First name*, Last name*, Gender(m or w)*, Phone number, Privilege of service ('publisher', 'auxiliary', 'regular', 'special', 'circuit', 'bethelite' or 'ldc'), Ministry privilege ('publisher', 'servant', 'elder', 'coordinator', 'secretary' or 'serviceOverseer'), Congregation, Account Language ('en', 'de', ...)
+    helpEncoding: The file has to be UTF-8 encoded to support all characters
+    uploadFile: Upload CSV-File
+    new: New Publishers
+    existing: Publishers with JW Management Account
+    name: Name
+    email: Email
+    add: Add Users
+  mergeAccounts:
+    title: Merge accoutns
+    description: Enter the credentials of the account in which you want to merge this account's permissions. You will be logged in into that account right away.
+    username: Username
+    password: Password
+    merge: Merge accounts

--- a/both/i18n/en-AU/navigation.en-AU.i18n.yml
+++ b/both/i18n/en-AU/navigation.en-AU.i18n.yml
@@ -1,0 +1,87 @@
+navigation:
+  welcome: Welcome
+  signUp: Sign up
+  home: Dashboard
+  dashboard:
+    details: Dashboard
+    myProjects:
+      details: My Projects
+    missingShiftReports:
+      details: Missing Shift Reports
+    upcomingShifts:
+      details: Upcoming Shifts
+    pendingRequests:
+      details: Pending Requests
+    olderShifts:
+      details: Previously done Shifts
+  profile: My Profile
+  shifts: Shifts
+  calendar: Calendar
+  wiki: Information Center
+  project:
+    search: Projects
+    details: Administration
+    support:
+      details: Support
+    insert: New project
+  settings: Settings
+  user:
+    search: Users
+  users:
+    online:
+      details: Online users
+  publisher:
+    search: Publishers
+    details: Publisher details
+    update: Edit publisher
+    insert: Add new publisher
+    profile:
+      vacation:
+        insert: Add new vacation
+      availability:
+        insert: Add new timeslot
+        details: Availability
+    password:
+      insert: Change password
+    permissions:
+      details: Publisher permission details
+      update: Update project permissions
+      tag:
+        details: Tag permission details
+        update: Update tag permission
+  publisherActions: Publisher Bulk Actions
+  reports: Reports
+  store: Store Room
+  vessel:
+    search: Vessels
+    details: Vessel details
+    update: Edit vessel
+    insert: New vessel
+    visit:
+      details: Visit details
+      insert: New visit
+      update: Edit visit
+      language:
+        insert: Add a language
+  note:
+    search: Notes
+    details: Note details
+    update: Edit note
+    insert: Add note
+  language:
+    details: Language
+    update: Edit language
+  login: Login
+  logout: Logout
+  loggingOut: Logging out...
+  firstLogin: First Login
+  forgotPassword: Forgot Password
+  resetPassword: Reset Password
+  terms: Terms of Usage
+  privacy: Data Privacy Policy
+  support: Support
+  version: Version
+  new: New
+  back: Back
+  save: Save
+  create: New entry

--- a/both/i18n/en-AU/notes.en-AU.i18n.yml
+++ b/both/i18n/en-AU/notes.en-AU.i18n.yml
@@ -1,0 +1,17 @@
+note:
+  search:
+    placeholder: Title oder text
+  entity:
+    title: Title
+    text: Text
+    lastChange: Last change
+    author: Author
+    datetime: Date
+    delete: Delete this note
+    deleteConfirmation: Do you really want to delete this note?
+  details:
+    sections:
+      title: Title
+      text: Text
+      meta: Last change
+      option: Options

--- a/both/i18n/en-AU/pages.en-AU.i18n.yml
+++ b/both/i18n/en-AU/pages.en-AU.i18n.yml
@@ -1,0 +1,213 @@
+login:
+  name: Login
+  welcome: Welcome to JW Management
+  text: Please enter your account details to log in
+  forgot: Forgot username or password?
+  create: Create an account
+  back: Back to Home Page
+forgotPassword:
+  name: Forgotten username or password
+  text: Please enter your email address. We will send you a link to reset your password, then. You'll automatically be logged in and can then look up your username.
+  button: Send password reset link
+  back: Back to Login Page
+  noUserForThisEmail: There is no account with this email address
+  multipleAccountsForThisEmail: There are multiple accounts with this email. Please specify a user.
+  emailMissing: Email address is missing
+  mailSent: You will receive an email shortly. Follow the link in the email to reset your password.
+resetPassword:
+  name: Reset password
+  text: Please enter a new password for %s %s.
+  noUserFound: <p>This link has expired</p><p>Please request another reset password mail.</p>
+  button: Change password
+  back: Back to Login Page
+profile:
+  name: My Profile
+  personalData: My personal details
+  changePicture: Edit image...
+  options:
+    title: Settings
+    helpText:
+      mergeAccounts: In JW Management you can do everything with just one single account. You just have to remember one username and password. If you have multiple accounts click on "Merge accounts" and enter the credentials for your other account. This will merge this account's permissions into the ones of the specified account.
+  availability:
+    title: Availability
+    helpText: Please mark the hours in which you are available.
+    shortTermCalls: I can be contacted in the short term
+    shortTermCallsAlways: Even if no availability is set
+    notifyViaEmail: I prefer to be contacted via Email.
+  speaks: Speaks
+  telefon: Phone
+  congregation: Congregation
+  language: Account language
+  languages: Foreign languages
+  gender: Gender
+  _gender:
+    brother: Brother
+    sister: Sister
+  publisher: Publisher
+  privilegeOfService: Privilege of service
+  _privilegeOfService:
+    auxiliaryPioneer: Auxiliary pioneer
+    pioneer: Regular pioneer
+    specialPioneer: Special pioneer
+    circuitOverseer: Circuit overseer
+    bethelite: Bethelite
+    fulltimeConstructionServant: Construction servant
+  ministryPrivilege: Congregation assignment
+  _ministryPrivilege:
+    ministerialServant: Ministerial servant
+    elder: Elder
+    coordinator: Coordinator of the Body of Elders
+    secretary: Secretary
+    serviceOverseer: Service overseer
+  placeholder:
+    telefon: (e.g. +447712345678)
+    congregation: Congregation
+    languages: Languages
+  changePassword: Change password
+  deleteAccount: Delete account
+  mergeAccounts: Merge accounts
+  vacation:
+    title: Holiday
+    helpText: Please add the periods in which you are not available.
+  until: until
+  addVacation: Add Holiday
+  deleteVacation: Delete this vacation
+  usernameTaken: This username is already taken by someone else. Please choose another.
+wiki:
+  name: Information Center
+  nameShort: Info
+  files: Files
+  addQuestion: Add question/title
+  edit: Edit
+  delete: Delete
+  noFiles: No files available
+  addTab: Add a new tab
+  editQuestion: Edit this question
+  removeFaq: Remove this question
+  editFaq: Edit this answer
+  changeFaq: Save this answer
+  cancelFaq: Cancel editing
+shifts:
+  name: Shifts
+  route: Route
+  addShift: Add a new shift
+  addWeek: Add a new week
+  requests: Requests
+  openRequests: Open Requests
+  automation: Automatic
+  template: Template
+  noVisibleShifts: No shifts by that tag this week
+  start: Start
+  end: End
+  visibility: Visibility:
+  helpText:
+    start: This is the first week to be created by the system.
+    end: This is the last week to be created by the system.
+    visibility: This defines how many weeks in advance the publishers will be able to see and request. Under consideration of the start-week and end-week, the system will automatically create the needed shifts.
+  weeks: weeks
+  sendWeek: Send Confirmations
+  hideNames: Hide all names in the shifts
+  showNames: Show all names in the shifts
+  editShifts: Edit the shifts
+  prevWeek: Go to the previous week
+  nextWeek: Go to the next week
+  sendWeek: Send confirmations for all shifts in this week per mail
+  shownTag: Shifts of this tag are currently shown
+  hiddenTag: Shifts of this tag are currently hidden
+  shift:
+    tag: Tag
+    schedule: Schedule
+    teamleader: Team leader
+    teams: Teams
+    noTeams: No Teams
+    participants: Participants
+    start: Start
+    end: End
+    requests: Request
+    requests_plural: Requests
+    requestsOf: Request of
+    requestsOf_plural: Requests of
+    teamleaders: TLs
+    noPermission: Only a project manager or shift manager is allowed to edit or schedule shifts.
+day:
+  removeAll: Remove all
+reports:
+  export: Export as CSV
+settings:
+  main:
+    title: Main Settings
+    id: ID
+    name:
+      text: Name
+      placeholder: Project name
+      helpText: In many cases the project name is the name of the congregation. For bigger projects including multiple congregations it can be the name of the city where the project will be carried out. If the project does not organize cart witnessing, the name can also reflect what will be organized with this project.
+    email:
+      text: Email
+      placeholder: Project email address
+      helpText: In emails like shift confirmations and team leader updates, this address will be set as the Reply-To address, so that if the recipients answer these emails, the reply will normally be sent to the inbox of this address if the recipient's email program is behaving correctly. Furthermore, this address will be notified e.g. on short-term participation cancellations.
+    language:
+      text: Language
+      helpText: If the system notifies the above listed address about changes, it will send the mails in the language you specify here.
+    deleteProject: Delete project
+  tags:
+    title: Tags
+    helpText: <p>Every shift has to be assigned a tag. Furthermore every user can be permitted or denied permission to be able to see shifts depending on the tags.</p><p>Tags can reflect different activities (e.g. Cart witnessing, Information stand, Street work, etc.). The dividing of shifts into different tags can be useful, for example if there are multiple shifts at the same time or if only certain publishers are trained in a specific type of public witnessing.</p><p>With every tag there can be a set of template weeks which have been defined previously. By using the automatic option when scheduling, the program can use these template weeks. This saves the project manager or shift manager time when scheduling.</p>
+    id: ID
+    name: Name
+    img:
+      name: Image
+      helpText: This image will be shown on the dashboard when clicking on 'Shifts'. It should explain the kind of tasks done in shifts of this tag. If you want to add a custom image, please send us an email to support@jwmanagement.org describing your idea.
+    templates: Templates
+    showTemplate: Edit shifts
+    editTemplate: Edit name
+    removeTemplate: Delete
+    addTemplate: Define new template
+    action: Action
+    none: No tags have been added yet
+    add: Add a new tag
+    remove: Remove this tag
+  teams:
+    title: Teams
+    helpText:
+      main: For every shift there has to be at least one team. Every team is assigned to a route or location. One participant of the shift is always member of one of these teams.
+      picture: Publishers will be able to see this picture. Therefore, it should give further information for the tasks in this team. For example you could create a route for this team on Google Maps or OpenStreetMap (depending on which has better coverage of your area) and upload a picture of that here.
+      link: This link will be connected with the picture. If the user clicks on the picture he will be forwarded to the address of this link. For example you could provide the link of the Google Maps or OpenStreetMap map here.
+      description: Here you can optionally set up a description for this team. For example you could explain some particularities of this team or route.
+    id: ID
+    name: Name
+    icon: Icon
+    picture: Picture
+    editPicture: Upload a picture for this team
+    noPicture: No picture uploaded
+    link: Link
+    description: Description
+    action: Action
+    none: No teams have been added yet
+    add: Add a new team
+    remove: Remove this teams
+  meetings:
+    title: Meeting Point
+    helpText:
+      main: For all the shift teams there can be a meeting point assigned to them. With that, teams can meet independently from each other. This can be useful, as when the route or location of the teams are so far apart that a common meeting would be too time consuming. Meeting points are defined with coordinates.
+      picture: Publishers will be able to see this picture. Therefore, it should give further information for the meeting point. For example you could upload a picture with the environment from Google Maps or OpenStreetMap (whichever one has better coverage of your area) here.
+    id: ID
+    name: Name
+    picture: Picture
+    editPicture: Upload a picture for this meeting point
+    noPicture: No picture uploaded
+    action: Action
+    none: No meeting points have been added yet
+    add: Add a new meeting point
+    remove: Remove this meeting point
+firstLogin:
+  name: Welcome
+  text: <p>We are looking forward to welcoming you.</p><p>Please set your personal username and password. From now on you will need these to authenticate on the system.</p><p>After that you can start using JW Management.</p><p>Enjoy!</p>
+  agreeTerms: I agree the <a href="/en/terms" target="blank">terms of usage</a> and the <a href="/en/privacy" target="blank">privacy policy</a>
+  button: Let's Go!
+  tokenError: Expired link. This is not valid any more. Please ask for a new E-Mail or try to reset your password.
+  tokenMissing: Invalid link. Please visit the link from the email.
+  usernameExists: This username is already in use. Please choose another one.
+  usernameMissing: Please provide a username.
+  agreeTermsMissing: Please agree the terms of usage and the privacy policy.
+  buttonCreateAccount: I need to create an account
+  buttonHaveAccount: I already have an account

--- a/both/i18n/en-AU/project.en-AU.i18n.yml
+++ b/both/i18n/en-AU/project.en-AU.i18n.yml
@@ -1,0 +1,53 @@
+project:
+  nameShort: Admin
+  entity:
+    _id: ID
+    name: Name
+    email: Project Email Address
+    language: Default language
+    languageValues:
+      de: German
+      en: English
+      fi: Finnish
+      fr: French
+      hu: Hungarian
+      it: Italian (partially)
+      pl: Polish
+      pt: Portuguese
+      ru: Russian
+    news:
+      text: News
+    shifts: Shifts
+    calendar: Calendar
+    knowledgeBase: Knowledge Base
+    settings: Settings
+    users: Users
+    publishers: Publishers
+    publisherActions: Publisher Bulk Actions
+    reports: Reports
+    store: Store
+    vessels: Vessels
+    notes: Notes
+    leave: Cancel any participation in this project
+    leaveConfirmation: Do you really want to leave this project and PERMANENTLY CANCEL ANY PARTICIPATION with it? This can't be undone!
+    supportPage: Support
+    support:
+      phone: Call us
+      discord: Write us on Discord (preferred)
+      github: Create a GitHub Issue
+      paypal: PayPal
+      iban: IBAN
+    noElements: No Projects found
+  details:
+    sections:
+      project: Project
+      modules: Modules
+      administration: Administration
+      participation: Participation
+  search:
+    placeholder: Search for projects
+  support:
+    details:
+      sections:
+        support: Get support
+        donate: Donate

--- a/both/i18n/en-AU/publishers.en-AU.i18n.yml
+++ b/both/i18n/en-AU/publishers.en-AU.i18n.yml
@@ -1,0 +1,179 @@
+publisher:
+  entity:
+    username: Username
+    profile:
+      firstname: First name
+      lastname: Last name
+      email: E-mail
+      telefon: Phone
+      gender: Gender
+      genderValues:
+        m: Brother
+        w: Sister
+      congregation: Congregation
+      pioneer: Privilege of service
+      pioneerValues:
+        publisher: Publisher
+        auxiliary: Auxiliary pioneer
+        regular: Regular pioneer
+        special: Special pioneer
+        circuit: Circuit overseer
+        bethelite: Bethelite
+        ldc: Construction servant
+      privilege: Congregation assignment
+      privilegeValues:
+        publisher: Publisher
+        servant: Ministerial servant
+        elder: Elder
+        coordinator: Coordinator of the Body of Elders
+        secretary: Secretary
+        serviceOverseer: Service overseer
+      language: Account language
+      languageValues:
+        de: German
+        en: English
+        fi: Finnish
+        fr: French
+        hu: Hungarian
+        it: Italian (partially)
+        pl: Polish
+        pt: Portuguese
+        ru: Russian
+        zh-TW: Chinese (Traditional) (partially)
+        zh-CN: Chinese (Simplified) (partially)
+      languages: Foreign languages
+      shortTermCalls: Receive understaffed mails
+      shortTermCallsAlways: Available in short term
+      availability:
+        new: Add new timeslot
+        noElements: No timeslot(s) entered
+        methodConfirmation: Do you really want to delete this timeslot?
+        mondays: Mondays
+        tuesdays: Tuesdays
+        wednesdays: Wednesdays
+        thursdays: Thursdays
+        fridays: Fridays
+        saturdays: Saturdays
+        sundays: Sundays
+        start: Start
+        startDateFormat: h a -
+        startValues:
+          0: 12 am
+          1: 1 am
+          2: 2 am
+          3: 3 am
+          4: 4 am
+          5: 5 am
+          6: 6 am
+          7: 7 am
+          8: 8 am
+          9: 9 am
+          10: 10 am
+          11: 11 am
+          12: 12 pm
+          13: 1 pm
+          14: 2 pm
+          15: 3 pm
+          16: 4 pm
+          17: 5 pm
+          18: 6 pm
+          19: 7 pm
+          20: 8 pm
+          21: 9 pm
+          22: 10 pm
+          23: 11 pm
+        end: End
+        endDateFormat: h a
+        endValues:
+          0: 1 am
+          1: 2 am
+          2: 3 am
+          3: 4 am
+          4: 5 am
+          5: 6 am
+          6: 7 am
+          7: 8 am
+          8: 9 am
+          9: 10 am
+          10: 11 am
+          11: 12 pm
+          12: 1 pm
+          13: 2 pm
+          14: 3 pm
+          15: 4 pm
+          16: 5 pm
+          17: 6 pm
+          18: 7 pm
+          19: 8 pm
+          20: 9 pm
+          21: 10 pm
+          22: 11 pm
+          23: 12 am
+        wholeDay: Whole day
+      vacation:
+        start: Start
+        end: End
+        new: Add new vacation
+        noElements: No vacations added
+        methodConfirmation: Do you really want to delete this vacation?
+        startDateFormat: DD/MM/YYYY [until]
+        endDateFormat: DD/MM/YYYY
+    password:
+      change: Change password
+      reset: Send password reset mail
+      resetConfirmation: Do you really want to send a reset password mail to the user?
+      password: Enter the new password
+      passwordRepeat: Re-enter the new password
+    permissions:
+      permissions: Permissions
+      project: Project permissions
+      projectValues:
+        admin: Project manager
+        shiftScheduler: Shift scheduler
+        shiftAdmin: Shift manager
+        storeAdmin: Store manager
+        member: Member
+      tag:
+        tag: Tag
+        role: Role
+        roleValues:
+          teamleader: Teamleader
+          substituteTeamleader: Substitute teamleader
+          participant: Participant
+          none: None
+    invite: Send project invitation
+    inviteConfirmation: Do you really want to send a project invitation mail to the user?
+    delete: Revoke this user's access to the project
+    deleteConfirmation: Do you really want to revoke this user's access to the project?
+  search:
+    placeholder: First name, Last name, E-mail, Phone or Username
+  details:
+    sections:
+      identification: Identification data
+      availability: Availability
+      vacations: Vacations
+      permissions: Permissions
+      password: Password
+      options: Options
+  profile:
+    availability:
+      details:
+        sections:
+          mondays: Availability on mondays
+          tuesdays: Availability on tuesdays
+          wednesdays: Availability on wednesdays
+          thursdays: Availability on thursdays
+          fridays: Availability on fridays
+          saturdays: Availability on saturdays
+          sundays: Availability on sundays
+  permissions:
+    details:
+      sections:
+        permissions:
+          project: Project permissions
+          tags: Tag permissions
+    tag:
+      details:
+        sections:
+          permissions:
+            tag: Tag permission

--- a/both/i18n/en-AU/push.en-AU.i18n.yml
+++ b/both/i18n/en-AU/push.en-AU.i18n.yml
@@ -1,0 +1,71 @@
+push:
+  footer: This is an automated mail. We don't expect an answer to it.
+  link: Open JWManagement
+  accountCreated:
+    subject: JWManagement Account Created!
+    headline: Welcome!
+    hello: Hello
+    text1: We would like to tell you that we have created an account for you in JWManagement. You can set your personal username and password by clicking on the button below.
+    text2: In case of problems please feel free to contact us.<br>We wish you much joy using JWManagement.<br>Your brothers from JWManagement
+    button: Let's Go!
+  teamCancellation:
+    subject: Team cancelled
+    headline: Team has been cancelled.
+    hello: Hello
+    text: Unfortunately we had to tell you that your team assignment on the __date__ at __time__ o'clock has been cancelled.
+    missingParticipant: A participant is missing. If there are enough participants the team can take place again.
+  confirmation:
+    subject: New Request Approved
+    headline: Your Request was approved!
+    hello: Hello
+    text: Your request for the following shift was approved: __date__ from __time__ o'clock
+    datetime: __date__ from __time__ o'clock
+  declined:
+    subject: Request not considered
+    headline: Request was not considered
+    hello: Hello
+    text1: Unfortunately your request for the following shift has not been granted: __date__ from __time__ o'clock.
+    text2: Thank you very much for your request!
+    datetime: __date__ from __time__ o'clock
+  reversal:
+    subject: Reversal
+    hello: Hello
+    text1: You were removed from the following team:
+    datetime: __date__ from __time__ o'clock
+  teamUpdate:
+    subject: Team changed
+    _changed: changed.
+    changed:
+      participant: A participant
+      time: The time
+      location: The location
+      leader: The team leader
+    hello: Hello
+    text1: You are marked as team member or leader so we would like to inform you about changes in your team.
+    text2: Here is the current team configuration
+    datetime: __date__ from __time__ o'clock
+  joinProject:
+    subject: Joined Project
+    headline: You were added to a project
+    hello: Hello
+    text1: You were invited to the following Project
+    text2: You find this project now on your dashboard at "My Projects".<br>Have a good time!
+  understaffed:
+    subject: Team understaffed
+    headline: Team is understaffed
+    hello: Hello
+    text1: the following Team is understaffed and needs a
+    text2: This shift needs help! __date__ from __time__ o'clock
+    datetime: __date__ from __time__ o'clock
+  toOrga:
+    hello: Hello Organisation Team
+    subject:
+      teamCancel: Team cancelled
+    text:
+      teamCancel: The team <b>"__team__"</b> on <b>__date__</b> at <b>__time__</b> o'clock were <u>cancelled</u>.
+  resetPassword:
+    subject: Reset Password
+    headline: Reset your Password
+    text1: Hello,<br>Please click the following button to set a new password:
+    button: Reset Password
+    text2: <p>Useful hints for secure password generation can be found in <a href="http://wol.jw.org/en/wol/d/r1/lp-e/102001451">g01 6/22 p. 31</a></p><p>If you didn't request a password reset, feel free to delete this email.</p>

--- a/both/i18n/en-AU/shift.en-AU.i18n.yml
+++ b/both/i18n/en-AU/shift.en-AU.i18n.yml
@@ -1,0 +1,3 @@
+shift:
+  entity:
+    noElements: No Shifts found

--- a/both/i18n/en-AU/store.en-AU.i18n.yml
+++ b/both/i18n/en-AU/store.en-AU.i18n.yml
@@ -1,0 +1,92 @@
+store:
+  title: Store Room Dashboard
+  short: Shortcut
+  language: Language
+  languages: Languages
+  total: Total
+  count: Count
+  showAll: Show all publications
+  hideAll: Hide all non-added publications
+  reset: Reset store room
+  noPublication: You haven't added a publication yet.<br>To add a publication, use the button to show all available publications.<br>Then select all publications that you keep in your store room.<br>Click on the publication to configure the langauges in which it is stocked.
+  startAddLanguage: Add Language
+  cancelAddLanguage: Cancel
+  close: Close
+  addLanguage: Add
+  removeLanguage: Remove this language
+  setup:
+    title: Please choose a store mode
+    support: Sorry this is not yet supported
+    description: Please choose a mode to initialize your store room.<br>You can change this later, if you need to.
+    simple:
+      name: Simple
+      description: With the simple mode, the system will automatically configure some basic item categories like "Books & Bibles", "Magazines", etc for you. These will be available in the report.
+    advanced:
+      name: Advanced
+      description: With the advanced mode you can decide which publications are available in which languages. You can define how many of them are in the store room and the system will keep them up to date with the information from the reports. With this you can determine which publications and languages work the best for your project.
+  type:
+    _books: Books
+    _brochures: Brochures
+    _magazines: Magazines
+    _tracts: Tracts
+    _misc: Miscellaneous
+  publication:
+    _CO-inv17: 2017 Regional Convention Invitation
+    _CO-inv18: 2018 Regional Convention Invitation
+    _CO-inv19: 2019 Regional Convention Invitation
+    _CO-inv20: 2020 Regional Convention Invitation
+    _bh: What Does the Bible Really Teach?
+    _bhs: What Can the Bible Teach Us?
+    _bi12: New World Translation of the Holy Scriptures (1984 Edition)
+    _bm: The Bible — What Is Its Message?
+    _cf: "Come Be My Follower"
+    _ct: Is There a Creator Who Cares About You?
+    _dv: DVD
+    _fg: Good News From God!
+    _fy: The Secret of Family Happiness
+    _gt: The Greatest Man Who Ever Lived
+    _gu: The Guidance of God — Our Way to Paradise
+    _hf: Your Family Can Be Happy
+    _inv: Invitation to congregation meetings
+    _jr: God's Word for Us Through Jeremiah
+    _jw: Jesus​—The Way, the Truth, the Life
+    _jwcd: Contact card for jw.org
+    _kt: Would You Like to Know the Truth?
+    _la: A Satisfying Life—How to Attain It
+    _lc: Was Life Created?
+    _ld: Listen to God
+    _lf: The Origin of Life — Five Questions Worth Asking
+    _lfb: Lessons You Can Learn From the Bible
+    _ll: Listen to God and Live Forever
+    _lgw: An Introction to God's Word
+    _lmn: "Look! I Am Making All Things New"
+    _lr: Learn From the Great Teacher
+    _mb: My Bible Lessons
+    _mi16: 2016 Memorial Invitation
+    _mi17: 2017 Memorial Invitation
+    _mi18: 2018 Memorial Invitation
+    _mi19: 2019 Memorial Invitation
+    _mi20: 2020 Memorial Invitation
+    _my: My Book of Bible Stories
+    _nwt: New World Translation of the Holy Scriptures (2013 Revision)
+    _ol: The Road to Everlasting Life — Have You Found It?
+    _pc: Lasting Peace and Happiness - How to Find Them
+    _ph: The Pathway to Peace and Happiness
+    _rj: Return to Jehovah
+    _rk: Real Faith — Your Key to a Happy Life
+    _rp: How to Find the Road to Paradise
+    _sgd: Studienhilfe zur Bibel
+    _t-30: How Do You View the Bible?
+    _t-31: How Do You View the Future?
+    _t-32: What Is the Key to Happy Family Life?
+    _t-33: Who Really Controls the World?
+    _t-34: Will Suffering Ever End?
+    _t-35: Can the Dead Really Live Again?
+    _t-36: What Is the Kingdom of God?
+    _t-37: Where Can We Find Answers to Life's Big Questions?
+    _we: When Someone You Love Dies
+    _wp/g: Watchtower / Awake
+    _yc: Teach Your Children
+    _yp1: Questions Young People Ask — Answers That Work, Volume 1
+    _yp2: Questions Young People Ask — Answers That Work, Volume 2
+    _ypq: Answers to 10 Questions Young People Ask

--- a/both/i18n/en-AU/swals.en-AU.i18n.yml
+++ b/both/i18n/en-AU/swals.en-AU.i18n.yml
@@ -1,0 +1,273 @@
+swal:
+  error: Error
+  publisherInOtherTeam: One of the selected publishers is already part of another team. Please remove them from there first.
+  onlyTeam: You can't delete this team. It is the only team in this shift. Every shift needs to have at least one team.
+  noTeamleader: Every team requires a team leader. Unfortunately this publisher does not have permission to serve as a team leader.
+  ownPermission: You are not allowed to revoke your own permissions. Another administrator has to do that.
+  approvalInformed: This participant has been informed that their request has been approved.
+  declinementInformed: This participant has been informed that their request was declined.
+  vacationEndInPast: The end date cannot be in the past.
+  missingTag: No tag defined. Please first define a tag under Admin > Settings
+  logout:
+    title: Hint
+    text: It is not necessary to log out unless you are on a shared computer. Your connection is encrypted and we save session information only in your local browser. Nobody else can see or hijack your session.
+    confirm: Logout
+    cancel: Cancel
+  invite:
+    user:
+      title: Invite Publisher?
+      text: This publisher <b>already has an account</b>, so no further account has to be created. Instead the publisher will <b>simply be given permission to access this project</b>.<br>Of course <b>we will inform him</b> about this change. <br><p>In case of more than one publisher registered with the same email address, please choose the right one:</p>
+    users:
+      title: Are you sure?
+      text: We will send an email to all selected publishers.
+      confirm: Invite
+      cancel: Cancel
+  sendMail:
+    confirmWeek:
+      title: Are you sure?
+      text: All approved publishers will receive a confirmation email and all declined publishers will receive a rejection email.
+      confirm: Yes
+      cancel: Cancel
+    confirmation:
+      title: Inform Publisher?
+      text: The publisher will be informed via email about the approval of this shift.
+      confirm: Yes
+      cancel: Cancel
+    declined:
+      title: Inform Publisher?
+      text: The publisher will be informed via email that the request was declined.
+      confirm: Yes
+      cancel: Cancel
+    selectTag:
+      title: Which Tag?
+      text: Please select the tag you want to send confirmation emails for:
+      confirm: OK
+      cancel: Cancel
+    teamUpdate:
+      user:
+        title: Team leader already informed
+        text: The team leader is already informed. Do you want to send an email with this update to him?
+        confirm: Yes
+        cancel: No
+      general:
+        title: Are you sure?
+        text: Already informed publishers will receive an email with the updated information about the team.
+        confirm: Yes
+        cancel: No
+    understaffed:
+      title: Inform Publishers?
+      text: Inform all publishers about this understaffed team?
+      confirm: Yes
+      cancel: No
+      teamleader:
+        title: Inform Team Leaders?
+        text: Inform all team leaders about this team?
+        confirm: Yes
+        cancel: No
+  add:
+    meeting:
+      title: Add new meeting point
+      text: ''
+      placeholder: Name
+      confirm: Add
+      cancel: Cancel
+    question:
+      title: Add a new question/title
+      text: ''
+      placeholder: Question/Title
+      inputError: You need to write something!
+      confirm: Add
+      cancel: Cancel
+    tab:
+      title: Add a new tab
+      text: ''
+      placeholder: Title
+      inputError: Invalid tab name!
+      confirm: Add
+      cancel: Cancel
+    tag:
+      title: Add new tag
+      text: ''
+      placeholder: Name
+      inputError: Invalid tag name!
+      confirm: Create
+      cancel: Cancel
+    team:
+      title: Add new team
+      text: ''
+      placeholder: Name
+      inputError: Invalid team name!
+      confirm: Add
+      cancel: Cancel
+    template:
+      title: Add template
+      text: ''
+      placeholder: Name
+      inputError: Invalid template name!
+      confirm: Add
+      cancel: Cancel
+    user:
+      title: Created!
+      text: The User was created.
+    users:
+      title: Are you sure?
+      text: All shown publishers will be added to the project.
+      confirm: Add
+      cancel: Cancel
+  update:
+    file:
+      title: Change Filename
+      text: ''
+      placeholder: Filename
+      inputError: Invalid filename!
+      confirm: Change
+      cancel: Cancel
+    password:
+      title: Change password
+      passwordOld: Old password
+      passwordNew1: New password
+      passwordNew2: Repeat new password
+      confirm: Change
+      cancel: Cancel
+      passwordChanged: Password changed
+    question:
+      title: Change Question
+      text: ''
+      placeholder: Question/Title
+      confirm: Change
+      cancel: Cancel
+    template:
+      title: Edit name
+      text: ''
+      placeholder: Name
+      confirm: Change
+      cancel: Cancel
+  delete:
+    account:
+      title: Really delete your account?
+      text: The account will be irreversibly deleted!
+      confirm: Delete my Account!
+      cancel: Cancel
+    allShifts:
+      title: Are you sure?
+      text: All shifts on this day and all requests for these shifts will irreversibly get deleted.
+      confirm: Delete
+      cancel: Cancel
+    file:
+      title: Are you sure?
+      text: The file will be deleted permanetly.
+      confirm: Delete
+      cancel: Cancel
+    language:
+      title: Really delete this language?
+      text: This will delete the language with its stock.
+      confirm: Delete
+      cancel: Cancel
+    meeting:
+      title: Really delete this meeting point?
+      text: The meeting point will also get removed from all existing shifts planned for the future.
+      checkInput: delete
+      placeholder: Please type "%s" for approval
+      inputError: The input did not match with "%s"
+      confirm: Delete
+      cancel: Cancel
+    note:
+      title: Really delete this note?
+      text: The note will be irreversibly deleted.
+      confirm: Delete
+      cancel: Cancel
+    project:
+      title: Really delete this project?
+      text: This will irreversibly delete all settings associated with this project, e.g. shifts, reports, requests, literature. Only the user accounts will remain.
+      checkInput: delete this project
+      placeholder: Please type "%s" for approval
+      inputError: The input did not match with "%s"
+      confirm: Delete
+      cancel: Cancel
+    publication:
+      title: Remove this publication from your store?
+      text: You will loose all stored data for this publication.
+      confirm: Remove
+      cancel: Cancel
+    question:
+      title: Are you sure?
+      text: This will irreversibly delete the question and its answer.
+      confirm: Delete
+      cancel: Cancel
+    shift:
+      title: Really delete this shift?
+      text: All requests for this shift will be removed.
+      confirm: Delete
+      cancel: Cancel
+    store:
+      title: Really reset store room?
+      text: This will delete all added publications.
+      confirm: Reset
+      cancel: Cancel
+    tab:
+      title: Are you sure?
+      text: The whole tab with all the questions will be deleted.
+      confirm: Delete
+      cancel: Cancel
+    tag:
+      title: Really delete tag?
+      text: All shifts belonging to this tag will also be deleted. This includes all requests for these shifts. <br><br> To confirm type in "delete".
+      checkInput: delete
+      placeholder: Please type "%s" for approval
+      inputError: The input did not match with "%s"
+      confirm: Delete
+      cancel: Cancel
+    team:
+      title: Really delete this team?
+      text: The team will get removed from all existing shifts planned for the future. approved requests for these shifts will be reallocated to other teams. <br><br> To confirm type in "delete".
+      checkInput: delete
+      placeholder: Please type "%s" for approval
+      inputError: The input did not match with "%s"
+      confirm: Delete
+      cancel: Cancel
+    template:
+      title: Really delete template?
+      text: ''
+      confirm: Delete
+      cancel: Cancel
+    user:
+      title: Really delete this user?
+      text: All project permissions will be revoked.
+      confirm: Delete
+      cancel: Cancel
+  request:
+    approve:
+      title: Really approve publisher?
+      text: This publisher has previously been declined. Therefore please make sure that the publisher is still able and willing to participate.
+      confirm: Yes
+      cancel: No
+    cancel:
+      title: Are you sure?
+      text: The team will be removed if you are the last participant.
+      confirm: Yes, cancel my participation
+      cancel: No
+    decline:
+      title: Really decline participant?
+      text: If participant is already informed he will receive a reversal email.
+      confirm: Yes
+      cancel: No
+    maxReached:
+      title: Too many users selected
+      text: Set team maximum limit from __attr1__ to __attr2__ and approve selected?
+      confirm: Approve selected
+      cancel: Cancel
+    minNotReached:
+      title: Not enough users selected
+      text: Set team minimum limit from __attr1__ to __attr2__ and approve selected?
+      confirm: Approve selected
+      cancel: Cancel
+    minReached:
+      title: Really decline participant?
+      text: This team's minimum limit has been reached. If you decline this user, the system will remove this team.
+      confirm: Remove team
+      cancel: No
+    noNewTeamleader:
+      title: Really decline participant?
+      text: Unfortunately there is no other possible team leader in this team. If you decline this user, the system will remove this team.
+      confirm: Remove team
+      cancel: No

--- a/both/i18n/en-AU/users.en-AU.i18n.yml
+++ b/both/i18n/en-AU/users.en-AU.i18n.yml
@@ -1,0 +1,23 @@
+user:
+  search:
+    placeholder: Search for users
+  entity:
+    username: Username
+    profile:
+      firstname: First name
+      lastname: Last name
+      email: Email
+    noElements: No user found
+users:
+  title: Publisher Bulk Actions
+  inviteUser: Send an invitation to non-activated publishers
+  uploadUserFile: Insert multiple publishers via a CSV-File
+  export: Export as CSV-File
+  sendToAll: Send an email to all publishers
+  sendToAllInTag: Send an email to all in tag %s
+  online:
+    details:
+      sections:
+        users:
+          online: Currently online users
+          idle: Currently idle users

--- a/both/i18n/en-AU/vessels.en-AU.i18n.yml
+++ b/both/i18n/en-AU/vessels.en-AU.i18n.yml
@@ -1,0 +1,212 @@
+vessel:
+  nameShort: Vessels
+  entity:
+    name: Vessel name
+    flag: Flag
+    type: Type
+    typeValues:
+      c: Container ship
+      cr: Cruise ship
+      mf: Cargo
+      mt: Tanker
+      p: Passenger ship
+      pt: Pushtow
+      f: Ferry
+      r: Reefer ship
+      rc: River cruise ship
+      ro: Ro-Ro
+      t: Tug
+      unknown: Unknown
+    callsign: Call sign
+    eni: ENI
+    imo: IMO
+    mmsi: MMSI
+    delete: Delete this vessel
+    deleteConfirmation: Do you really want to delete this vessel?
+    visit:
+      new: Note a new visit
+      noElements: This ship has not been visited yet
+      delete: Delete this visit
+      deleteConfirmation: Do you really want to delete this visit?
+      person: Publisher
+      email: Publisher email address
+      phone: Publisher phone number
+      isUserVisible: Make your contact data visible for other publishers?
+      date: Date
+      dateNext: Next visit preferably after
+      harbor: Harbor
+      harborId: Harbor
+      harborIdValues:
+        placeholder: Select a harbor
+        atasc: (ATASC) Aschach an der Donau
+        atena: (ATENA) Enns
+        atkre: (ATKRE) Krems
+        atlnz: (ATLNZ) Linz
+        atvie: (ATVIE) Wien
+        atybb: (ATYBB) Ybbs an der Donau
+        chbbs: (CHBBS) Basel Schweizerhalle
+        chbsl: (CHBSL) Basel
+        chrfd: (CHRFD) Rheinfelden CH
+        deand: (DEAND) Andernach
+        debbg: (DEBBG) Brandenburg
+        debed: (DEBED) Bendorf
+        debek: (DEBEK) Bernkastel
+        deber: (DEBER) Berlin
+        debke: (DEBKE) Brake
+        deblm: (DEBLM) Blumenthal
+        debmk: (DEBMK) Borkum
+        debon: (DEBON) Bonn
+        debot: (DEBOT) Bottrop
+        debrb: (DEBRB) Brunsbüttel
+        debre: (DEBRE) Bremen
+        debrv: (DEBRV) Bremerhaven
+        debsh: (DEBSH) Breisach
+        debsk: (DEBSK) Burgstaaken
+        debum: (DEBUM) Buesum
+        debuz: (DEBUZ) Bützfleth
+        decgn: (DECGN) Köln
+        decux: (DECUX) Cuxhaven
+        dedeg: (DEDEG) Deggendorf
+        dedhu: (DEDHU) Huckingen
+        dedmg: (DEDMG) Chempark Dormagen
+        dedrp: (DEDRP) Dörpen
+        dedrs: (DEDRS) Dresden
+        dedtm: (DEDTM) Dortmund
+        dedui: (DEDUI) Duisburg
+        dedus: (DEDUS) Düsseldorf
+        deeck: (DEECK) Eckernförde
+        deehm: (DEEHM) Senheim
+        deeme: (DEEME) Emden
+        deflf: (DEFLF) Flensburg
+        defra: (DEFRA) Frankfurt am Main
+        degdo: (DEGDO) Godorf
+        degek: (DEGEK) Gelsenkirchen
+        deger: (DEGER) Germersheim
+        deget: (DEGET) Geesthacht
+        deghm: (DEGHM) Gernsheim
+        degic: (DEGIC) Grünendeich
+        degkg: (DEGKG) Grosskrotzenburg
+        deglu: (DEGLU) Glückstadt
+        degmz: (DEGMZ) Grömitz
+        degrd: (DEGRD) Greifswald
+        degre: (DEGRE) Greetsiel
+        deham: (DEHAM) Hamburg
+        dehau: (DEHAU) Hanau
+        dehcs: (DEHCS) Höchst
+        dehee: (DEHEE) Herne
+        dehgl: (DEHGL) Helgoland
+        dehhf: (DEHHF) Heiligenhafen
+        dehil: (DEHIL) Hildesheim
+        dehmm: (DEHMM) Hamm
+        dehus: (DEHUS) Husum
+        dejwp: (DEJWP) Jade Weser Port
+        dekae: (DEKAE) Karlsruhe
+        dekap: (DEKAP) Kappeln
+        dekdu: (DEKDU) Krefeld-Ürdingen
+        dekeh: (DEKEH) Kehl
+        dekel: (DEKEL) Kiel
+        dekob: (DEKOB) Koblenz
+        dekre: (DEKRE) Krefeld
+        delah: (DELAH) Lahnstein
+        delbc: (DELBC) Lübeck
+        delbm: (DELBM) Lubim
+        deldb: (DELDB) Ladbergen
+        delee: (DELEE) Leer
+        delev: (DELEV) Chempark Leverkusen
+        delew: (DELEW) Lemwerder
+        delig: (DELIG) Lingen/Ems
+        delnu: (DELNU) Lauenburg
+        delue: (DELUE) Lunen
+        delwr: (DELWR) Ludwigshafen
+        demai: (DEMAI) Mainz
+        demal: (DEMAL) Marl
+        demhg: (DEMHG) Mannheim
+        demid: (DEMID) Minden
+        demlm: (DEMLM) Mühlheim am Main
+        demnf: (DEMNF) Mondorf
+        demoe: (DEMOE) Mölln
+        demrt: (DEMRT) Luxport Mertert
+        demsr: (DEMSR) Münster
+        demuk: (DEMUK) Mukran
+        dendt: (DENDT) Neustadt (in Holstein)
+        dened: (DENED) Neuwied
+        denha: (DENHA) Nordenham
+        denhl: (DENHL) Niehl
+        denho: (DENHO) Neustadt in Holstein
+        denoe: (DENOE) Norddeich
+        denrd: (DENRD) Norderney
+        denss: (DENSS) Neuss
+        denue: (DENUE) Nürnberg
+        deoff: (DEOFF) Offenbach am Main
+        deolu: (DEOLU) Oldersum
+        depap: (DEPAP) Papenburg
+        depas: (DEPAS) Passau
+        depei: (DEPEI) Peine
+        deplo: (DEPLO) Plochingen
+        deput: (DEPUT) Puttgarden
+        depyk: (DEPYK) Spyck
+        dereg: (DEREG) Regensburg
+        deren: (DEREN) Rendsburg
+        derfn: (DERFN) Rheinfelden D
+        dergm: (DERGM) Nuremberg
+        dersk: (DERSK) Rostock
+        derue: (DERUE) Rüdesheim
+        desar: (DESAR) Salzgitter
+        desas: (DESAS) Sassnitz
+        descw: (DESCW) Schweinfurt
+        deses: (DESES) Schierstein
+        desgw: (DESGW) Schwelgern
+        desls: (DESLS) Schleswig
+        despe: (DESPE) Speyer
+        despy: (DESPY) Spay
+        desrc: (DESRC) Scharnebeck
+        desta: (DESTA) Stade
+        destl: (DESTL) Stralsund
+        destr: (DESTR) Stuttgart
+        dests: (DESTS) Stadersand
+        detri: (DETRI) Trier
+        detrv: (DETRV) Travemunde
+        deuck: (DEUCK) Ükermünde
+        deuel: (DEUEL) Uelzen
+        deviw: (DEVIW) Vierow
+        dewed: (DEWED) Wedel
+        dewes: (DEWES) Wesel
+        dewib: (DEWIB) Wiesbaden
+        dewis: (DEWIS) Wismar
+        dewlg: (DEWLG) Wesseling
+        dewlr: (DEWLR) Weil am Rhein
+        dewnu: (DEWNU) Weissenthurm
+        dewoe: (DEWOE) Wörth
+        dewol: (DEWOL) Wolgast
+        dewor: (DEWOR) Worms
+        dewue: (DEWUE) Würzburg
+        dewvn: (DEWVN) Wilhelmshaven
+        dewyk: (DEWYK) Wyk auf Föhr
+        dezin: (DEZIN) Zinnowitz
+        plgdn: (PLGDN) Gdansk
+        plgdy: (PLGDY) Gdynia
+        plswi: (PLSWI) Swinoujscie
+        plszz: (PLSZZ) Szczecin
+      country: Country
+      language:
+        new: Add a language
+        noElements: No languages noted yet
+        methodConfirmation: Do you really want to delete this language?
+        languageIds: Language
+        languageIdsValues:
+          placeholder: Select a language
+      languages: Languages on board
+  search:
+    placeholder: Vessel name, call sign, ENI, IMO or MMSI
+  details:
+    sections:
+      identification: Identification data
+      visit: Visit data
+    dateFormat: DD/MM/YYYY
+  visit:
+    details:
+      sections:
+        main: Visit data
+        language: Language data
+        option: Options
+      dateFormat: DD/MM/YYYY

--- a/both/i18n/en-AU/welcome.en-AU.i18n.yml
+++ b/both/i18n/en-AU/welcome.en-AU.i18n.yml
@@ -1,0 +1,34 @@
+welcome:
+  links:
+    home: Home
+    features: Features
+    contact: Contact
+    login: Login
+    dashboard: Open Dashboard
+  header:
+    title: Advanced shift management
+    description: JW Management is a highly configurable shift management system for Jehovah's Witnesses. Built to power projects like the metropolitan witnessing and construction projects.
+  divider:
+    first:
+      title: Multiple Tags
+      description: Easily separate different shifts with tags; assign publishers to the tags where shifts can be requested. Also define which publishers receive permission to serve as team leaders.
+    second:
+      title: Shift Teams
+      description: Define one or more teams in a shift. Each will have its own team-leader. Provide further information for every team, such as a description, a picture with a route, meeting points and more.
+    third:
+      title: Store Room
+      description: Manage your store room via JW Management. After each shift a team leader can report what has been placed. The system then automatically updates the publications' stock with the number of placements taken. Get notified if a publication is low on stock.
+    fourth:
+      title: Notifications
+      description: Through the powerful notification system, you can be notified of your requests, confirmations or refusals, as well as changes to your shifts, with the ability to reply.
+  feature1:
+    title: Multifunctional Tool
+    description: <p>Although JW Management is optimized for public witnessing projects, the main focus is on being a shift management system.</p><p>You could also manage your assembly's stewards, a Bible exhibition, a construction project or something else.</p><p>Where possible, we are willing to optimize the system for your needs too.</p>
+  feature2:
+    title: Free & Open-Source
+    description: <p>Visit the Repository and see how we develop JW Management. You can suggest features, report bugs or directly propose a 'Pull Request' with your code changes.</p><p>If you would like to translate the system into another language, send us the translation files as 'Pull Request' or via email.</p>
+    free: Completely free
+    repo: GitHub Repository
+  footer:
+    terms: Terms of usage
+    privacy: Privacy policy

--- a/imports/framework/Constants/SystemLanguages.js
+++ b/imports/framework/Constants/SystemLanguages.js
@@ -3,6 +3,7 @@ const SystemLanguages = {
   allowedValues: [
     'de',
     'en',
+    'en-AU',
     'fi',
     'fr',
     'hu',


### PR DESCRIPTION
Australian English has different date format, also in near future some expressions will be adapted too.

These features have been added:
===

  1. **Description:** In Australian English the date format is DD/MM/YYYY instead of MM/DD/YYYY also some expressions are different.  I have created an en-AU language for English (Australia) where the date format is corrected and I will be adding new expressions to the translation.
     **Tested by doing:** In my local machine i can change the languages between English, German and English (Australian) and the date format changes properly.

> **Note:** Please if I am wrong with the changes I am making let me know and I will change it as recommended. 

**Thank you very much for your hard work.**
