### PR TITLE
Tweaks to English Language

### DIFF
--- a/imports/i18n/en/authentication.js
+++ b/imports/i18n/en/authentication.js
@@ -7,7 +7,7 @@ const authentication = {
   },
   signUp: {
     name: 'Sign Up',
-    text: '<p>You want to test the system and manage your own project?<p></p>Just enter your details below to create an account.</p>',
+    text: '<p>Would you like to test the system and manage your own project?<p></p>Just enter your details below to create an account.</p>',
     bySigningYouAgreeTo: 'By signing up, you agree to our',
     terms: 'terms of usage',
     andOur: 'and our',
@@ -16,11 +16,11 @@ const authentication = {
   },
   forgotPassword: {
     name: 'Forgotten username or password',
-    text: 'Please enter your email address. We will send you a link to reset your password, then. You\'ll automatically be logged in and can then look up your username.',
+    text: 'Please enter your email address. We will send you a link to reset your password. The link will log you in automatically and you can then look up your username.',
     button: 'Send password reset link',
     back: 'Back to sign in',
     noUserForThisEmail: 'There is no account with this email address',
-    multipleAccountsForThisEmail: 'There are multiple accounts with this email. Please specify a user.',
+    multipleAccountsForThisEmail: 'There are multiple accounts with this email address. Please specify a user.',
     emailMissing: 'Email address is missing',
     mailSent: 'You will receive an email shortly. Follow the link in the email to reset your password.'
   },
@@ -36,8 +36,8 @@ const authentication = {
     text: '<p>We are looking forward to welcoming you.</p><p>Please set your personal username and password. From now on you will need these to authenticate on the system.</p><p>After that you can start using JW Management.</p><p>Enjoy!</p>',
     agreeTerms: 'I agree the <a href="/en/terms" target="blank">terms of usage</a> and the <a href="/de/privacy" target="blank">privacy policy</a>',
     button: 'Let\'s Go!',
-    tokenError: 'Expired link. This is not valid any more. Please ask for a new E-Mail or try to reset your password.',
-    plainTextToken: 'Seems like you\'re mail client doesn\'t support html mails. Please open the mail with a modern mail client to get the full link.',
+    tokenError: 'Expired link. This is not valid any more. Please ask for a new email or try to reset your password.',
+    plainTextToken: 'Seems like you\'re mail client doesn\'t support HTML mails. Please open the mail with a modern mail client to get the full link.',
     tokenMissing: 'Invalid link. Please visit the link from the email.',
     usernameExists: 'This username is already in use. Please choose another one.',
     usernameMissing: 'Please provide a username.',

--- a/imports/i18n/en/errors.js
+++ b/imports/i18n/en/errors.js
@@ -2,16 +2,16 @@ const error = {
   generic: 'Sorry, an error occurred. Please try again.',
   '403': 'This username already exists',
   nameRequired: 'Please enter the name of this vessel',
-  callsignUnique: 'A vessel with this call sign is already existing',
-  eniUnique: 'A vessel with this ENI number is already existing',
-  imoUnique: 'A vessel with this IMO number is already existing',
-  mmsiUnique: 'A vessel with this MMSI number is already existing',
+  callsignUnique: 'A vessel with this call sign already exists',
+  eniUnique: 'A vessel with this ENI number already exists',
+  imoUnique: 'A vessel with this IMO number already exists',
+  mmsiUnique: 'A vessel with this MMSI number already exists',
   missingField: 'Please fill out all fields',
   incorrectPassword: 'This password seems to be incorrect',
   noAccountFound: 'No account with this username or email could be found',
   multipleAccountsFound: 'There are multiple accounts with this email. Please use the username',
   passwordsDoNotMatch: 'The passwords do not match',
-  passwordTooShort: 'The password has to have at least 8 characters'
+  passwordTooShort: 'The password must have at least 8 characters'
 }
 
 export default error

--- a/imports/i18n/en/mail.js
+++ b/imports/i18n/en/mail.js
@@ -13,7 +13,7 @@ const mail = {
     subject: 'Team cancelled',
     headline: 'Team has been cancelled.',
     hello: 'Hello',
-    text: 'Unfortunately we your team assignment on <b>{{date}}</b> at <b>{{time}}</b> o\'clock has been <u>cancelled</u>.',
+    text: 'Unfortunately your team assignment on <b>{{date}}</b> at <b>{{time}}</b> o\'clock has been <u>cancelled</u>.',
     missingParticipant: 'There are not enough paricipants. If enough participants join, the assignment can take place again.'
   },
   confirmation: {

--- a/imports/i18n/en/mail.js
+++ b/imports/i18n/en/mail.js
@@ -1,5 +1,5 @@
 const mail = {
-  footer: 'This is an automated mail. We don\\\'t expect an answer to it.',
+  footer: 'This is an automated mail. We don\'t expect an answer to it.',
   link: 'Open JW Management',
   accountCreated: {
     subject: 'JW Management Account Created!',
@@ -13,8 +13,8 @@ const mail = {
     subject: 'Team cancelled',
     headline: 'Team has been cancelled.',
     hello: 'Hello',
-    text: 'Unfortunately we had to tell you that your team assignment on <b>{{date}}</b> at <b>{{time}}</b> o\'clock was <u>cancelled</u>.',
-    missingParticipant: 'A participant is missing. If there are enough participants the team can take place again.'
+    text: 'Unfortunately we your team assignment on <b>{{date}}</b> at <b>{{time}}</b> o\'clock has been <u>cancelled</u>.',
+    missingParticipant: 'There are not enough paricipants. If enough participants join, the assignment can take place again.'
   },
   confirmation: {
     subject: 'New Request Approved',
@@ -64,7 +64,7 @@ const mail = {
     headline: 'Reset your Password',
     text1: 'Hello,<br>Please click the following button to set a new password:',
     button: 'Reset Password',
-    text2: '<p>Useful hints for secure password generation can be found in <a href="http://wol.jw.org/en/wol/d/r1/lp-e/102001451">g01 6/22 p. 31</a></p><p>If you didn\'t request a password reset, feel free to delete this email.</p>'
+    text2: '<p>Useful hints for secure password generation can be found in <a href="https://wol.jw.org/en/wol/d/r1/lp-e/102001451">g01 6/22 p. 31</a></p><p>If you didn\'t request a password reset, feel free to delete this email.</p>'
   }
 }
 

--- a/imports/i18n/en/modals.js
+++ b/imports/i18n/en/modals.js
@@ -176,7 +176,7 @@ const modal = {
     title: 'User-File upload',
     helpText: 'Order of personal data (* fields are required): <br> Email*, First name*, Last name*, Gender(m or w)*, Phone number, Privilege of service (\'publisher\', \'auxiliary\', \'regular\', \'special\', \'circuit\', \'bethelite\' or \'ldc\'), Ministry privilege (\'publisher\', \'servant\', \'elder\', \'coordinator\', \'secretary\' or \'serviceOverseer\'), Congregation, Account Language (\'en\', \'de\', ...), Foreign languages spoken (e.g. \'German, French\'), Roles (see user export for an example)',
     helpEncoding: 'The file has to be UTF-8 encoded to support all characters',
-    uploadFile: 'Upload CSV-File',
+    uploadFile: 'Upload CSV File',
     new: 'New Publishers',
     existing: 'Publishers with JW Management Account',
     name: 'Name',

--- a/imports/i18n/en/modals.js
+++ b/imports/i18n/en/modals.js
@@ -17,7 +17,7 @@ const modal = {
     defineTemplate: 'Define template',
     action: 'Create week',
     text: {
-      top: 'Choose a week, that the template week will get applied to:',
+      top: 'Choose a week that the template week will get applied to:',
       bottom: 'Choose the template week:'
     }
   },
@@ -39,7 +39,7 @@ const modal = {
     teams: 'Teams assigned to this shift',
     helpText: {
       tag: 'Set this shift tag. All users with permissions on this tag can view the shift.',
-      scheduling: 'With \'approve immediately\' requests will be approved automatically, when the minimum participant limit for the next team is reached.'
+      scheduling: 'With \'approve immediately\', requests will be approved automatically when the minimum participant limit for the next team is reached.'
     },
     addTeam: 'Add a new team',
     teamMin: 'Minimum participants:',

--- a/imports/i18n/en/pages.js
+++ b/imports/i18n/en/pages.js
@@ -6,7 +6,7 @@ const pages = {
     options: {
       title: 'Settings',
       helpText: {
-        mergeAccounts: 'In JW Management you can do everything with just one single account. You just have to remember one username and password. If you have multiple accounts click on "Merge accounts" and enter the credentials for your other account. This will merge this account\'s permissions into the ones of the specified account.'
+        mergeAccounts: 'In JW Management you can do everything with just one account. You just have to remember one username and password. If you have multiple accounts click on "Merge accounts" and enter the credentials for your other account. This will merge this account\'s permissions into the specified account.'
       }
     },
     availability: {
@@ -142,11 +142,11 @@ const pages = {
       email: {
         text: 'Email',
         placeholder: 'Project email address',
-        helpText: 'In emails like shift confirmations and team leader updates, this address will be set as the Reply-To address, so that if the recipients answer these emails, the reply will normally be sent to the inbox of this address if the recipient\'s email program is behaving correctly. Furthermore, this address will be notified e.g. on short-term participation cancellations.'
+        helpText: 'In emails like shift confirmations and team leader updates, this address will be set as the Reply-To address, so that if the recipients answer these emails, the reply will normally be sent to the inbox of this address if the recipient\'s email program is behaving correctly. Furthermore, this address will be notified (e.g. on short-term participation cancellations).'
       },
       language: {
         text: 'Language',
-        helpText: 'If the system notifies the above listed address about changes, it will send the mails in the language you specify here.'
+        helpText: 'If the system notifies the address listed above about changes, it will send the mails in the language you specify here.'
       },
       deleteProject: 'Delete project'
     },
@@ -172,7 +172,7 @@ const pages = {
     teams: {
       title: 'Teams',
       helpText: {
-        main: 'For every shift there has to be at least one team. Teams can e.g. represent different routes or locations. A participant of the shift is always member of one of these teams.',
+        main: 'For every shift there has to be at least one team. Teams can represent different routes or locations. A participant of the shift is always member of one of these teams.',
         picture: 'Publishers will be able to see this picture. Therefore, it should give further information for the tasks in this team. For example you could create a route for this team on Google Maps or OpenStreetMap (depending on which has better coverage of your area) and upload a picture of that here.',
         link: 'This link will be connected with the picture. If the user clicks on the picture he will be forwarded to the address of this link. For example you could provide the link of the Google Maps or OpenStreetMap map here.',
         description: 'Here you can optionally set up a description for this team. For example you could explain some particularities of this team or route.'
@@ -193,7 +193,7 @@ const pages = {
     meetings: {
       title: 'Meeting Point',
       helpText: {
-        main: 'For all the shift teams there can be a meeting point assigned to them. With that, teams can meet independently from each other. This can be useful, as when the route or location of the teams are so far apart that a common meeting would be too time consuming.',
+        main: 'For all the shift teams there can be a meeting point assigned. With that, teams can meet independently from each other. This can be useful when the route or location of the teams are so far apart that a common meeting would be too time consuming.',
         picture: 'Publishers will be able to see this picture. Therefore, it should give further information for the meeting point. For example you could upload a picture with the environment from Google Maps or OpenStreetMap (whichever one has better coverage of your area) here.'
       },
       id: 'ID',

--- a/imports/i18n/en/swals.js
+++ b/imports/i18n/en/swals.js
@@ -17,7 +17,7 @@ const swal = {
   invite: {
     user: {
       title: 'Invite Publisher?',
-      text: 'This publisher <b>already has an account</b>, so no further account has to be created. Instead the publisher will <b>simply be given permission to access this project</b>.<br>Of course <b>we will inform him</b> about this change. <br><p>In case of more than one publisher registered with the same email address, please choose the right one:</p>'
+      text: 'This publisher <b>already has an account</b>, so no further account has to be created. Instead the publisher will <b>simply be given permission to access this project</b>.<br>Of course <b>we will inform him</b> about this change. <br><p>In case more than one publisher has registered with the same email address, please choose the right one:</p>'
     },
     users: {
       title: 'Are you sure?',
@@ -47,14 +47,14 @@ const swal = {
     },
     selectTag: {
       title: 'Which Tag?',
-      text: 'Please select the tag you want to send confirmation emails for:',
+      text: 'Please select the tag you would like to send confirmation emails for:',
       confirm: 'OK',
       cancel: 'Cancel'
     },
     teamUpdate: {
       user: {
         title: 'Team leader already informed',
-        text: 'The team leader is already informed. Do you want to send an email with this update to him?',
+        text: 'The team leader has already been informed. Do you want to send an email with this update to him?',
         confirm: 'Yes',
         cancel: 'No'
       },
@@ -212,7 +212,7 @@ const swal = {
     },
     project: {
       title: 'Really delete this project?',
-      text: 'This will irreversibly delete all settings associated with this project, e.g. shifts, reports, requests, literature. Only the user accounts will remain.',
+      text: 'This will irreversibly delete all settings associated with this project (e.g. shifts, reports, requests, literature). Only the user accounts will remain.',
       checkInput: 'delete this project',
       placeholder: 'Please type "{{0}}" for approval',
       inputError: 'The input did not match with "{{0}}"',
@@ -260,7 +260,7 @@ const swal = {
     },
     team: {
       title: 'Really delete this team?',
-      text: 'The team will get removed from all existing shifts planned for the future. approved requests for these shifts will be reallocated to other teams. <br><br> To confirm type in "delete".',
+      text: 'The team will get removed from all existing shifts planned for the future. Approved requests for these shifts will be reallocated to other teams. <br><br> To confirm type in "delete".',
       checkInput: 'delete',
       placeholder: 'Please type "{{0}}" for approval',
       inputError: 'The input did not match with "{{0}}"',
@@ -283,7 +283,7 @@ const swal = {
   request: {
     approve: {
       title: 'Really approve publisher?',
-      text: 'This publisher has previously been declined. Therefore please make sure that the publisher is still able and willing to participate.',
+      text: 'This publisher has previously been declined. Please make sure that the publisher is still able and willing to participate.',
       confirm: 'Yes',
       cancel: 'No'
     },

--- a/imports/i18n/en/users.js
+++ b/imports/i18n/en/users.js
@@ -2,7 +2,7 @@ const users = {
   title: 'Publisher Bulk Actions',
   inviteUser: 'Send an invitation to non-activated publishers',
   uploadUserFile: 'Insert multiple publishers via a CSV-File',
-  export: 'Export as CSV-File',
+  export: 'Export as CSV File',
   sendToAll: 'Send an email to all publishers',
   sendToAllInTag: 'Send an email to all in tag {{0}}',
   online: {


### PR DESCRIPTION
This pull request only includes changes to language files for English. Some of the grammar was a little odd. Possibly because of being translated from another language. The changes are minor but will hopefully help give some clarity to our English speaking friends. :-)

Since I'm not sure if the English option in settings is strictly for United States, I am leaving some things unchanged (e.g. referring to "Holiday" instead of "Vacation"). If the main English option is also used in Europe, I wouldn't want to mess things up for them. Maybe adding `English (United States)` as an option would be useful. Let me know.